### PR TITLE
Return an empty list instead of None

### DIFF
--- a/repo_health/check_travis_yml.py
+++ b/repo_health/check_travis_yml.py
@@ -63,7 +63,7 @@ def fixture_python_version(parsed_data_travis):
     if python_versions:
         python_versions = sorted(python_versions)
     else:
-        python_versions = None
+        python_versions = []
     return python_versions
 
 @add_key_to_metadata((module_dict_key, "py38_tests"))


### PR DESCRIPTION
when there aren't any Python versions.