### PR TITLE
Adding timestamp check for data processing

### DIFF
--- a/repo_health_dashboard/configuration.yaml
+++ b/repo_health_dashboard/configuration.yaml
@@ -1,17 +1,8 @@
 main:
     check_order:
-        - openedx_yaml.parsable
-        - openedx_yaml.oep-18
-        - openedx_yaml.oep-2
-        - openedx_yaml.oep-30
-        - openedx_yaml.oep-30.reason
-        - openedx_yaml.oep-30.state
-        - openedx_yaml.oep-7
         - openedx_yaml.owner
-        - makefile.exists
-        - makefile.has_upgrade_target
+        - makefile.upgrade
     key_aliases:
-        makefile.has_upgrade_target: makefile_upgrade
         tox_ini.has_section.tox: tox_tox_section
         repo_structure.has_python_files: python_files
         repo_structure.requirements.base.in: req_base.in

--- a/repo_health_dashboard/repo_health_dashboard.py
+++ b/repo_health_dashboard/repo_health_dashboard.py
@@ -6,9 +6,9 @@ import os
 import argparse
 import glob
 import codecs
-import yaml
 import datetime
-import pdb
+
+import yaml
 
 from .utils import utils
 

--- a/repo_health_dashboard/repo_health_dashboard.py
+++ b/repo_health_dashboard/repo_health_dashboard.py
@@ -7,6 +7,8 @@ import argparse
 import glob
 import codecs
 import yaml
+import datetime
+import pdb
 
 from .utils import utils
 
@@ -34,13 +36,11 @@ def main():
         default=None,
     )
     parser.add_argument(
-        "--output-html",
-        help="path to HTML output",
-        dest="output_html",
-        default="dashboard",
+        "--data-life-time",
+        help="days: how many days before individual data yaml files are outdated",
+        default=1,
     )
     args = parser.parse_args()
-
     # collect configurations if they were input
     configurations = {
         "main": {"check_order": [], "repo_name_order": [], "key_aliases": {}}
@@ -63,6 +63,11 @@ def main():
         with codecs.open(file_path, "r", "utf-8") as f:
             file_data = f.read()
             parsed_file_data = yaml.safe_load(file_data)
+            date_of_collection = parsed_file_data["TIMESTAMP"]
+            today_date = datetime.datetime.now().date()
+            days_since_collection = abs((today_date - date_of_collection).days)
+            if days_since_collection > args.data_life_time:
+                continue
             data[repo_name] = parsed_file_data
     output = utils.squash_and_standardize_metadata_by_repo(data)
     for key, configuration in configurations.items():


### PR DESCRIPTION
repo-health-data contains alot of old data(from repos that are deleted or renamed). This old data is adding alot of noise to our final csv output. So adding this data lifetime check to make sure old files are ignored.