### PR TITLE
Add initial checks for data from the GitHub API ARCHBOM-1310

### DIFF
--- a/docs/check_function.rst
+++ b/docs/check_function.rst
@@ -9,16 +9,10 @@ A check function is a python test function with "check_" as a prefix rather than
 Anatomy of a check
 ------------------
 
-1. Decorator to add info about check
- - use either "@health_metadata" or "@add_key_to_metadata" decorator
-2. function inputs: pytest fixtures
- - if check is gathering info(which it should), it should use "all_results" fixture
-3. function doc string
- - if using "@add_key_to_metadata", this doc string will be treated like the doc for the key
- - otherwise, write something here to help developers in the future
-4. function body
- - code to gather information
- - make sure to add info into "all_results" dict
+1. **Decorator to add info about check.** Use either "@health_metadata" or "@add_key_to_metadata" decorator.
+2. **Function inputs: pytest fixtures.**  If the check is gathering info (which it should), it should use the "all_results" fixture
+3. **Function doc string.**  If using "@add_key_to_metadata", this doc string will be treated like the doc for the key.  Otherwise, write something here to help developers in the future.
+4. **Function body.**  Code to gather information.  Make sure to add info into the "all_results" dict.
 
 Available Fixtures:
 --------------------
@@ -45,8 +39,5 @@ Each key added to all_results should be well documented. Decorators are used to 
 
 - the decorators are imported from pytest-repo-health
 - there are currently two available decorators
- - "@health_metadata" decorator
-  - use if your check adds more than one key to "all_results"
- - "@add_key_to_metadata" decorator
-  - if the function(check) is only adding one key to "all_results"
-  - this decorator assumes the function doc string is the documentation on the key
+    - "@health_metadata" decorator - use if your check adds more than one key to "all_results"
+    - "@add_key_to_metadata" decorator - if the function (check) is only adding one key to "all_results". This decorator assumes the function doc string is the documentation on the key

--- a/repo_health/check_github.py
+++ b/repo_health/check_github.py
@@ -1,0 +1,163 @@
+"""
+Checks to collect useful information from the GitHub API about the target repository.
+"""
+
+import functools
+import operator
+
+from pytest_repo_health import health_metadata
+
+MODULE_DICT_KEY = "github"
+
+FETCH_REPOSITORY_LANGUAGES = """
+query fetch_repository_languages ($repository_id: ID!, $cursor: String=null) {
+  node (id: $repository_id) {
+    ... on Repository {
+      languages (first: 10, after: $cursor) {
+        edges {
+          node {
+            __typename
+            color
+            id
+            name
+          }
+          size
+        }
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+      }
+    }
+  }
+}
+"""
+
+LANGUAGES = [
+    "css",
+    "dockerfile",
+    "go",
+    "groovy",
+    "html",
+    "java",
+    "javascript",
+    "makefile",
+    "objective-c",
+    "php",
+    "python",
+    "ruby",
+    "shell",
+]
+
+
+async def fetch_languages(repo):
+    """
+    Fetch the number of bytes of each language in the target repo from the GitHub API.
+    This should ideally be part of github.py, but it hasn't been implemented there yet.
+    """
+    client = repo.http
+    kwargs = {"repository_id": repo.id}
+    edges = list()
+
+    cursor = None
+    has_next_page = True
+
+    while has_next_page:
+        json = {
+            "query": FETCH_REPOSITORY_LANGUAGES,
+            "variables": kwargs.update(cursor=cursor) or kwargs,
+        }
+
+        data = await client.request(json=json)
+        data = functools.reduce(operator.getitem, ["node", "languages"], data)
+
+        edges.extend(data["edges"])
+
+        cursor = data["pageInfo"]["endCursor"]
+        has_next_page = data["pageInfo"]["hasNextPage"]
+
+    result = {}
+    for edge in edges:
+        name = edge["node"]["name"]
+        result[name.lower()] = edge["size"]
+    return result
+
+
+@health_metadata(
+    [MODULE_DICT_KEY],
+    {
+        "allows_merge_commit": "Are PRs merged with a merge commit on the repository?",
+        "allows_rebase_merge": "Is rebase-merging enabled on the repository?",
+        "allows_squash_merge": "Is squash-merging enabled on the repository?",
+        "code_of_conduct": "The name of the code of conduct for the repository (if any)",
+        "created_at": "The date and time when the repository was created.",
+        "default_branch": "The name of the repository's default branch",
+        "description": "The description text for the repository (if any)",
+        "disk_usage_kb": "The number of kilobytes the repository occupies on disk",
+        "fork_count": "How many GitHub forks there are of the repository",
+        "has_issues": "Is the repository's the issues feature enabled?",
+        "has_wiki": "Is the repository's wiki feature enabled?",
+        "is_archived": "Is the repository unmaintained?",
+        "is_disabled": "Is the repository disabled?",
+        "is_locked": "Has the repository been locked?",
+        "is_private": "Is the repository private?",
+        "last_push": "When was the repository last pushed to?",
+        "license": "The name of the repository's software license",
+    },
+)
+async def check_settings(all_results, github_repo):
+    """
+    Get all the fields of interest from the GitHub repository object itself.
+    """
+    results = all_results[MODULE_DICT_KEY]
+    results["allows_merge_commit"] = github_repo.allows_merge_commit
+    results["allows_rebase_merge"] = github_repo.allows_rebase_merge
+    results["allows_squash_merge"] = github_repo.allows_squash_merge
+    coc = github_repo.code_of_conduct
+    results["code_of_conduct"] = coc.name if coc else None
+    results["created_at"] = github_repo.created_at
+    results["default_branch"] = github_repo.default_branch
+    results["description"] = github_repo.description
+    results["disk_usage_kb"] = github_repo.disk_usage
+    results["fork_count"] = github_repo.fork_count
+    results["has_issues"] = github_repo.has_issues
+    results["has_wiki"] = github_repo.has_wiki
+    results["is_archived"] = github_repo.is_archived
+    results["is_disabled"] = github_repo.is_disabled
+    results["is_fork"] = github_repo.is_fork
+    results["is_locked"] = github_repo.is_locked
+    results["is_private"] = github_repo.is_private
+    results["last_push"] = github_repo.pushed_at
+    repo_license = github_repo.license
+    results["license"] = repo_license.nickname or repo_license.name
+
+
+@health_metadata(
+    ["language_bytes"],
+    {
+        "css": "The number of bytes of CSS files in the repository",
+        "dockerfile": "The number of bytes of Dockerfiles in the repository",
+        "go": "The number of bytes of Go code in the repository",
+        "groovy": "The number of bytes of Groovy code in the repository",
+        "html": "The number of bytes of HTML files in the repository",
+        "java": "The number of bytes of Java code in the repository",
+        "javascript": "The number of bytes of JavaScript code in the repository",
+        "makefile": "The number of bytes of Makefiles in the repository",
+        "objective-c": "The number of bytes of Objective-C code in the repository",
+        "php": "The number of bytes of PHP code in the repository",
+        "python": "The number of bytes of Python code in the repository",
+        "ruby": "The number of bytes of Ruby code in the repository",
+        "shell": "The number of bytes of shell scripts in the repository",
+    }
+)
+async def check_languages(all_results, github_repo):
+    """
+    Get the number of bytes of each programming language in the repository.
+    """
+    results = all_results["language_bytes"]
+    languages = await fetch_languages(github_repo)
+    for language, size in languages.items():
+        results[language] = size
+    for language in LANGUAGES:
+        if language not in languages:
+            results[language] = 0


### PR DESCRIPTION
Added checks for all the information of interest that could easily be obtained from the `github.py` package, and put in a little extra effort to get the byte count for each programming language (which `github.py` hasn't implemented yet).  Also fixed some reST formatting in the docs.

Example output from the new checks for this repo itself:

```yaml
github:
    allows_merge_commit: true
    allows_rebase_merge: true
    allows_squash_merge: true
    code_of_conduct: null
    created_at: 2020-03-24 13:36:50
    default_branch: master
    description: ''
    disk_usage_kb: 110
    fork_count: 3
    has_issues: true
    has_wiki: true
    is_archived: false
    is_disabled: false
    is_fork: false
    is_locked: false
    is_private: false
    last_push: 2020-07-17 06:30:26
    license: Apache License 2.0
language_bytes:
    css: 0
    dockerfile: 0
    go: 0
    groovy: 0
    html: 0
    java: 0
    javascript: 0
    makefile: 2248
    objective-c: 0
    php: 0
    python: 27455
    ruby: 0
    shell: 744
```