### PR TITLE
Drop Python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,13 @@ sudo: false
 language: python
 matrix:
   include:
-  - python: 3.5
-    env: TOX_ENV=py35
+  - python: 3.6
+    env: TOX_ENV=py36
+  - python: 3.7
+    env: TOX_ENV=py37
   - python: 3.8
     env: TOX_ENV=py38
-  - python: 3.5
+  - python: 3.6
     env: TOX_ENV=quality
 install:
 - pip install -r requirements/travis.txt

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,8 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
     ],
     entry_points={

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{35,38}
+envlist = py{36,37,38}
 
 [doc8]
 max-line-length = 120


### PR DESCRIPTION
Allows us to upgrade some dependencies and avoid confusion regarding the appropriate aiohttp version (recent versions only support Python 3.5.3 and above).