### PR TITLE
Add ownership checks ARCHBOM-1383

### DIFF
--- a/repo_health/check_ownership.py
+++ b/repo_health/check_ownership.py
@@ -13,14 +13,18 @@ MODULE_DICT_KEY = "ownership"
 
 
 class KnownError(Exception):
-    """Known exception cases where we won't need a stack trace."""
+    """
+    Known exception cases where we won't need a stack trace.
+    """
     def __init__(self, message):
         super().__init__(message)
         self.message = message
 
 
 def find_worksheet(google_creds_file, spreadsheet_url, worksheet_id):
-    """Authenticate to Google and return the matching worksheet."""
+    """
+    Authenticate to Google and return the matching worksheet.
+    """
     all_worksheets = gspread.service_account(filename=google_creds_file) \
                             .open_by_url(spreadsheet_url) \
                             .worksheets()
@@ -41,6 +45,10 @@ def find_worksheet(google_creds_file, spreadsheet_url, worksheet_id):
     },
 )
 def check_ownership(all_results, git_origin_url):
+    """
+    Get all the fields of interest from the tech ownership spreadsheet entry
+    for the repository.
+    """
     try:
         google_creds_file = os.environ["REPO_HEALTH_GOOGLE_CREDS_FILE"]
         spreadsheet_url = os.environ["REPO_HEALTH_OWNERSHIP_SPREADSHEET_URL"]

--- a/repo_health/check_ownership.py
+++ b/repo_health/check_ownership.py
@@ -1,0 +1,64 @@
+"""
+Checks to fetch repository ownership information from the Google Sheets speadsheet.
+"""
+import re
+import os
+
+import gspread
+import pytest
+from pytest_repo_health import health_metadata
+from pytest_repo_health.fixtures.github import URL_PATTERN
+
+MODULE_DICT_KEY = "ownership"
+
+
+class KnownError(Exception):
+    """Known exception cases where we won't need a stack trace."""
+    def __init__(self, message):
+        super().__init__(message)
+        self.message = message
+
+
+def find_worksheet(google_creds_file, spreadsheet_url, worksheet_id):
+    """Authenticate to Google and return the matching worksheet."""
+    all_worksheets = gspread.service_account(filename=google_creds_file) \
+                            .open_by_url(spreadsheet_url) \
+                            .worksheets()
+    matching = list(filter(lambda w: w.id == worksheet_id, all_worksheets))
+    if not matching:
+        raise KnownError("Cannot find a worksheet with ID {}".format(worksheet_id))
+    return matching[0]
+
+
+@health_metadata(
+    [MODULE_DICT_KEY],
+    {
+        "theme": "Theme that owns the component",
+        "squad": "Squad that owns the component",
+        "priority": "How critical is the component to edX?",
+        "description": "Description of the what the component is",
+        "notes": "Notes maintained by the owner",
+    },
+)
+def check_ownership(all_results, git_origin_url):
+    try:
+        google_creds_file = os.environ["REPO_HEALTH_GOOGLE_CREDS_FILE"]
+        spreadsheet_url = os.environ["REPO_HEALTH_OWNERSHIP_SPREADSHEET_URL"]
+        worksheet_id = int(os.environ["REPO_HEALTH_REPOS_WORKSHEET_ID"])
+    except KeyError:
+        pytest.skip("At least one of the REPO_HEALTH_* environment variables is missing")
+    match = re.search(URL_PATTERN, git_origin_url)
+    assert match is not None
+    org_name = match.group("org_name")
+    repo_name = match.group("repo_name")
+    repo_url = "https://github.com/{}/{}".format(org_name, repo_name)
+    results = all_results[MODULE_DICT_KEY]
+    worksheet = find_worksheet(google_creds_file, spreadsheet_url, worksheet_id)
+    for row in worksheet.get_all_records():
+        if row["repo url"] != repo_url:
+            continue
+        results["theme"] = row["owner.theme"]
+        results["squad"] = row["owner.squad"]
+        results["priority"] = row["owner.priority"]
+        results["description"] = row["Description"]
+        results['notes'] = row["Notes"]

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,6 +1,6 @@
 # Core requirements for using this application
 -c constraints.txt
 
+gspread                    # Access information from Google Sheets (the ownership spreadsheet)
 pyyaml                     # Read and write YAML files
 pytest-repo-health         # plugin used to run the checks in this repo
-

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,27 +7,42 @@
 aiohttp==3.6.2            # via github.py, pytest-aiohttp
 async-timeout==3.0.1      # via aiohttp
 attrs==19.3.0             # via aiohttp, pytest
-chardet==3.0.4            # via aiohttp
+cachetools==4.1.1         # via google-auth
+certifi==2020.6.20        # via requests
+chardet==3.0.4            # via aiohttp, requests
 gitdb==4.0.5              # via gitpython
 github.py==0.5.0          # via pytest-repo-health
 gitpython==3.1.7          # via pytest-repo-health
+google-auth-oauthlib==0.4.1  # via gspread
+google-auth==1.20.0       # via google-auth-oauthlib, gspread
+gspread==3.6.0            # via -r requirements/base.in
 idna-ssl==1.1.0           # via aiohttp
-idna==2.10                # via idna-ssl, yarl
+idna==2.10                # via idna-ssl, requests, yarl
 importlib-metadata==1.7.0  # via pluggy, pytest
-iniconfig==1.0.0          # via pytest
+iniconfig==1.0.1          # via pytest
 more-itertools==8.4.0     # via pytest
 multidict==4.7.6          # via aiohttp, yarl
+oauthlib==3.1.0           # via requests-oauthlib
 packaging==20.4           # via pytest
 pluggy==0.13.1            # via pytest
 py==1.9.0                 # via pytest
+pyasn1-modules==0.2.8     # via google-auth
+pyasn1==0.4.8             # via pyasn1-modules, rsa
 pyparsing==2.4.7          # via packaging
 pytest-aiohttp==0.3.0     # via pytest-repo-health
 pytest-repo-health==1.1.1  # via -r requirements/base.in
 pytest==6.0.1             # via pytest-aiohttp, pytest-repo-health
 pyyaml==5.3.1             # via -r requirements/base.in, pytest-repo-health
-six==1.15.0               # via packaging
+requests-oauthlib==1.3.0  # via google-auth-oauthlib
+requests==2.24.0          # via gspread, requests-oauthlib
+rsa==4.6                  # via google-auth
+six==1.15.0               # via google-auth, packaging
 smmap==3.0.4              # via gitdb
 toml==0.10.1              # via pytest
 typing-extensions==3.7.4.2  # via aiohttp, yarl
-yarl==1.5.0               # via aiohttp
+urllib3==1.25.10          # via requests
+yarl==1.5.1               # via aiohttp
 zipp==3.1.0               # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,7 +9,9 @@ appdirs==1.4.4            # via -r requirements/quality.txt, -r requirements/tra
 astroid==2.3.3            # via -r requirements/quality.txt, pylint, pylint-celery
 async-timeout==3.0.1      # via -r requirements/quality.txt, -r requirements/travis.txt, aiohttp
 attrs==19.3.0             # via -r requirements/quality.txt, -r requirements/travis.txt, aiohttp, pytest
-chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/travis.txt, aiohttp
+cachetools==4.1.1         # via -r requirements/quality.txt, -r requirements/travis.txt, google-auth
+certifi==2020.6.20        # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/travis.txt, aiohttp, requests
 click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, click-log, edx-lint, pip-tools
 diff-cover==3.0.1         # via -r requirements/dev.in
@@ -19,12 +21,15 @@ filelock==3.0.12          # via -r requirements/quality.txt, -r requirements/tra
 gitdb==4.0.5              # via -r requirements/quality.txt, -r requirements/travis.txt, gitpython
 github.py==0.5.0          # via -r requirements/quality.txt, -r requirements/travis.txt, pytest-repo-health
 gitpython==3.1.7          # via -r requirements/quality.txt, -r requirements/travis.txt, pytest-repo-health
+google-auth-oauthlib==0.4.1  # via -r requirements/quality.txt, -r requirements/travis.txt, gspread
+google-auth==1.20.0       # via -r requirements/quality.txt, -r requirements/travis.txt, google-auth-oauthlib, gspread
+gspread==3.6.0            # via -r requirements/quality.txt, -r requirements/travis.txt
 idna-ssl==1.1.0           # via -r requirements/quality.txt, -r requirements/travis.txt, aiohttp
-idna==2.10                # via -r requirements/quality.txt, -r requirements/travis.txt, idna-ssl, yarl
+idna==2.10                # via -r requirements/quality.txt, -r requirements/travis.txt, idna-ssl, requests, yarl
 importlib-metadata==1.7.0  # via -r requirements/quality.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/quality.txt, -r requirements/travis.txt, virtualenv
 inflect==4.1.0            # via jinja2-pluralize
-iniconfig==1.0.0          # via -r requirements/quality.txt, -r requirements/travis.txt, pytest
+iniconfig==1.0.1          # via -r requirements/quality.txt, -r requirements/travis.txt, pytest
 isort==4.3.21             # via -r requirements/quality.txt, pylint
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via diff-cover, jinja2-pluralize
@@ -33,10 +38,13 @@ markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, pylint
 more-itertools==8.4.0     # via -r requirements/quality.txt, -r requirements/travis.txt, pytest
 multidict==4.7.6          # via -r requirements/quality.txt, -r requirements/travis.txt, aiohttp, yarl
+oauthlib==3.1.0           # via -r requirements/quality.txt, -r requirements/travis.txt, requests-oauthlib
 packaging==20.4           # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
-pip-tools==5.3.0          # via -r requirements/pip-tools.txt, -r requirements/travis.txt
+pip-tools==5.3.1          # via -r requirements/pip-tools.txt, -r requirements/travis.txt
 pluggy==0.13.1            # via -r requirements/quality.txt, -r requirements/travis.txt, diff-cover, pytest, tox
 py==1.9.0                 # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
+pyasn1-modules==0.2.8     # via -r requirements/quality.txt, -r requirements/travis.txt, google-auth
+pyasn1==0.4.8             # via -r requirements/quality.txt, -r requirements/travis.txt, pyasn1-modules, rsa
 pycodestyle==2.6.0        # via -r requirements/quality.txt
 pydocstyle==5.0.2         # via -r requirements/quality.txt
 pygments==2.6.1           # via diff-cover
@@ -49,7 +57,10 @@ pytest-aiohttp==0.3.0     # via -r requirements/quality.txt, -r requirements/tra
 pytest-repo-health==1.1.1  # via -r requirements/quality.txt, -r requirements/travis.txt
 pytest==6.0.1             # via -r requirements/quality.txt, -r requirements/travis.txt, pytest-aiohttp, pytest-repo-health
 pyyaml==5.3.1             # via -r requirements/quality.txt, -r requirements/travis.txt, pytest-repo-health
-six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, diff-cover, edx-lint, packaging, pip-tools, tox, virtualenv
+requests-oauthlib==1.3.0  # via -r requirements/quality.txt, -r requirements/travis.txt, google-auth-oauthlib
+requests==2.24.0          # via -r requirements/quality.txt, -r requirements/travis.txt, gspread, requests-oauthlib
+rsa==4.6                  # via -r requirements/quality.txt, -r requirements/travis.txt, google-auth
+six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, diff-cover, edx-lint, google-auth, packaging, pip-tools, tox, virtualenv
 smmap==3.0.4              # via -r requirements/quality.txt, -r requirements/travis.txt, gitdb
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 toml==0.10.1              # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
@@ -57,10 +68,12 @@ tox-battery==0.6.1        # via -r requirements/dev.in
 tox==3.18.1               # via -r requirements/quality.txt, -r requirements/travis.txt, tox-battery
 typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
 typing-extensions==3.7.4.2  # via -r requirements/quality.txt, -r requirements/travis.txt, aiohttp, yarl
-virtualenv==20.0.28       # via -r requirements/quality.txt, -r requirements/travis.txt, tox
+urllib3==1.25.10          # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+virtualenv==20.0.29       # via -r requirements/quality.txt, -r requirements/travis.txt, tox
 wrapt==1.11.2             # via -r requirements/quality.txt, astroid
-yarl==1.5.0               # via -r requirements/quality.txt, -r requirements/travis.txt, aiohttp
+yarl==1.5.1               # via -r requirements/quality.txt, -r requirements/travis.txt, aiohttp
 zipp==3.1.0               # via -r requirements/quality.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip
+# setuptools

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -11,7 +11,8 @@ async-timeout==3.0.1      # via -r requirements/test.txt, aiohttp
 attrs==19.3.0             # via -r requirements/test.txt, aiohttp, pytest
 babel==2.8.0              # via sphinx
 bleach==3.1.5             # via readme-renderer
-certifi==2020.6.20        # via requests
+cachetools==4.1.1         # via -r requirements/test.txt, google-auth
+certifi==2020.6.20        # via -r requirements/test.txt, requests
 chardet==3.0.4            # via -r requirements/test.txt, aiohttp, doc8, requests
 distlib==0.3.1            # via -r requirements/test.txt, virtualenv
 doc8==0.8.1               # via -r requirements/doc.in
@@ -21,20 +22,26 @@ filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 gitdb==4.0.5              # via -r requirements/test.txt, gitpython
 github.py==0.5.0          # via -r requirements/test.txt, pytest-repo-health
 gitpython==3.1.7          # via -r requirements/test.txt, pytest-repo-health
+google-auth-oauthlib==0.4.1  # via -r requirements/test.txt, gspread
+google-auth==1.20.0       # via -r requirements/test.txt, google-auth-oauthlib, gspread
+gspread==3.6.0            # via -r requirements/test.txt
 idna-ssl==1.1.0           # via -r requirements/test.txt, aiohttp
 idna==2.10                # via -r requirements/test.txt, idna-ssl, requests, yarl
 imagesize==1.2.0          # via sphinx
 importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest, stevedore, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/test.txt, virtualenv
-iniconfig==1.0.0          # via -r requirements/test.txt, pytest
+iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 jinja2==2.11.2            # via sphinx
 markupsafe==1.1.1         # via jinja2
 more-itertools==8.4.0     # via -r requirements/test.txt, pytest
 multidict==4.7.6          # via -r requirements/test.txt, aiohttp, yarl
+oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib
 packaging==20.4           # via -r requirements/test.txt, bleach, pytest, sphinx, tox
 pbr==5.4.5                # via stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 py==1.9.0                 # via -r requirements/test.txt, pytest, tox
+pyasn1-modules==0.2.8     # via -r requirements/test.txt, google-auth
+pyasn1==0.4.8             # via -r requirements/test.txt, pyasn1-modules, rsa
 pygments==2.6.1           # via doc8, readme-renderer, sphinx
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-aiohttp==0.3.0     # via -r requirements/test.txt, pytest-repo-health
@@ -43,9 +50,11 @@ pytest==6.0.1             # via -r requirements/test.txt, pytest-aiohttp, pytest
 pytz==2020.1              # via babel
 pyyaml==5.3.1             # via -r requirements/test.txt, pytest-repo-health
 readme-renderer==26.0     # via -r requirements/doc.in
-requests==2.24.0          # via sphinx
+requests-oauthlib==1.3.0  # via -r requirements/test.txt, google-auth-oauthlib
+requests==2.24.0          # via -r requirements/test.txt, gspread, requests-oauthlib, sphinx
 restructuredtext-lint==1.3.1  # via doc8
-six==1.15.0               # via -r requirements/test.txt, bleach, doc8, edx-sphinx-theme, packaging, readme-renderer, tox, virtualenv
+rsa==4.6                  # via -r requirements/test.txt, google-auth
+six==1.15.0               # via -r requirements/test.txt, bleach, doc8, edx-sphinx-theme, google-auth, packaging, readme-renderer, tox, virtualenv
 smmap==3.0.4              # via -r requirements/test.txt, gitdb
 snowballstemmer==2.0.0    # via sphinx
 sphinx==3.1.2             # via -r requirements/doc.in, edx-sphinx-theme
@@ -59,10 +68,10 @@ stevedore==3.2.0          # via doc8
 toml==0.10.1              # via -r requirements/test.txt, pytest, tox
 tox==3.18.1               # via -r requirements/test.txt
 typing-extensions==3.7.4.2  # via -r requirements/test.txt, aiohttp, yarl
-urllib3==1.25.10          # via requests
-virtualenv==20.0.28       # via -r requirements/test.txt, tox
+urllib3==1.25.10          # via -r requirements/test.txt, requests
+virtualenv==20.0.29       # via -r requirements/test.txt, tox
 webencodings==0.5.1       # via bleach
-yarl==1.5.0               # via -r requirements/test.txt, aiohttp
+yarl==1.5.1               # via -r requirements/test.txt, aiohttp
 zipp==3.1.0               # via -r requirements/test.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.3.0          # via -r requirements/pip-tools.in
+pip-tools==5.3.1          # via -r requirements/pip-tools.in
 six==1.15.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -9,7 +9,9 @@ appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
 astroid==2.3.3            # via pylint, pylint-celery
 async-timeout==3.0.1      # via -r requirements/test.txt, aiohttp
 attrs==19.3.0             # via -r requirements/test.txt, aiohttp, pytest
-chardet==3.0.4            # via -r requirements/test.txt, aiohttp
+cachetools==4.1.1         # via -r requirements/test.txt, google-auth
+certifi==2020.6.20        # via -r requirements/test.txt, requests
+chardet==3.0.4            # via -r requirements/test.txt, aiohttp, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
 distlib==0.3.1            # via -r requirements/test.txt, virtualenv
@@ -18,19 +20,25 @@ filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 gitdb==4.0.5              # via -r requirements/test.txt, gitpython
 github.py==0.5.0          # via -r requirements/test.txt, pytest-repo-health
 gitpython==3.1.7          # via -r requirements/test.txt, pytest-repo-health
+google-auth-oauthlib==0.4.1  # via -r requirements/test.txt, gspread
+google-auth==1.20.0       # via -r requirements/test.txt, google-auth-oauthlib, gspread
+gspread==3.6.0            # via -r requirements/test.txt
 idna-ssl==1.1.0           # via -r requirements/test.txt, aiohttp
-idna==2.10                # via -r requirements/test.txt, idna-ssl, yarl
+idna==2.10                # via -r requirements/test.txt, idna-ssl, requests, yarl
 importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/test.txt, virtualenv
-iniconfig==1.0.0          # via -r requirements/test.txt, pytest
+iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/quality.in, pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 more-itertools==8.4.0     # via -r requirements/test.txt, pytest
 multidict==4.7.6          # via -r requirements/test.txt, aiohttp, yarl
+oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib
 packaging==20.4           # via -r requirements/test.txt, pytest, tox
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 py==1.9.0                 # via -r requirements/test.txt, pytest, tox
+pyasn1-modules==0.2.8     # via -r requirements/test.txt, google-auth
+pyasn1==0.4.8             # via -r requirements/test.txt, pyasn1-modules, rsa
 pycodestyle==2.6.0        # via -r requirements/quality.in
 pydocstyle==5.0.2         # via -r requirements/quality.in
 pylint-celery==0.3        # via edx-lint
@@ -42,14 +50,21 @@ pytest-aiohttp==0.3.0     # via -r requirements/test.txt, pytest-repo-health
 pytest-repo-health==1.1.1  # via -r requirements/test.txt
 pytest==6.0.1             # via -r requirements/test.txt, pytest-aiohttp, pytest-repo-health
 pyyaml==5.3.1             # via -r requirements/test.txt, pytest-repo-health
-six==1.15.0               # via -r requirements/test.txt, astroid, edx-lint, packaging, tox, virtualenv
+requests-oauthlib==1.3.0  # via -r requirements/test.txt, google-auth-oauthlib
+requests==2.24.0          # via -r requirements/test.txt, gspread, requests-oauthlib
+rsa==4.6                  # via -r requirements/test.txt, google-auth
+six==1.15.0               # via -r requirements/test.txt, astroid, edx-lint, google-auth, packaging, tox, virtualenv
 smmap==3.0.4              # via -r requirements/test.txt, gitdb
 snowballstemmer==2.0.0    # via pydocstyle
 toml==0.10.1              # via -r requirements/test.txt, pytest, tox
 tox==3.18.1               # via -r requirements/test.txt
 typed-ast==1.4.1          # via astroid
 typing-extensions==3.7.4.2  # via -r requirements/test.txt, aiohttp, yarl
-virtualenv==20.0.28       # via -r requirements/test.txt, tox
+urllib3==1.25.10          # via -r requirements/test.txt, requests
+virtualenv==20.0.29       # via -r requirements/test.txt, tox
 wrapt==1.11.2             # via astroid
-yarl==1.5.0               # via -r requirements/test.txt, aiohttp
+yarl==1.5.1               # via -r requirements/test.txt, aiohttp
 zipp==3.1.0               # via -r requirements/test.txt, importlib-metadata, importlib-resources
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,32 +8,47 @@ aiohttp==3.6.2            # via -r requirements/base.txt, github.py, pytest-aioh
 appdirs==1.4.4            # via virtualenv
 async-timeout==3.0.1      # via -r requirements/base.txt, aiohttp
 attrs==19.3.0             # via -r requirements/base.txt, aiohttp, pytest
-chardet==3.0.4            # via -r requirements/base.txt, aiohttp
+cachetools==4.1.1         # via -r requirements/base.txt, google-auth
+certifi==2020.6.20        # via -r requirements/base.txt, requests
+chardet==3.0.4            # via -r requirements/base.txt, aiohttp, requests
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 gitdb==4.0.5              # via -r requirements/base.txt, gitpython
 github.py==0.5.0          # via -r requirements/base.txt, pytest-repo-health
 gitpython==3.1.7          # via -r requirements/base.txt, pytest-repo-health
+google-auth-oauthlib==0.4.1  # via -r requirements/base.txt, gspread
+google-auth==1.20.0       # via -r requirements/base.txt, google-auth-oauthlib, gspread
+gspread==3.6.0            # via -r requirements/base.txt
 idna-ssl==1.1.0           # via -r requirements/base.txt, aiohttp
-idna==2.10                # via -r requirements/base.txt, idna-ssl, yarl
+idna==2.10                # via -r requirements/base.txt, idna-ssl, requests, yarl
 importlib-metadata==1.7.0  # via -r requirements/base.txt, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via virtualenv
-iniconfig==1.0.0          # via -r requirements/base.txt, pytest
+iniconfig==1.0.1          # via -r requirements/base.txt, pytest
 more-itertools==8.4.0     # via -r requirements/base.txt, pytest
 multidict==4.7.6          # via -r requirements/base.txt, aiohttp, yarl
+oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib
 packaging==20.4           # via -r requirements/base.txt, pytest, tox
 pluggy==0.13.1            # via -r requirements/base.txt, pytest, tox
 py==1.9.0                 # via -r requirements/base.txt, pytest, tox
+pyasn1-modules==0.2.8     # via -r requirements/base.txt, google-auth
+pyasn1==0.4.8             # via -r requirements/base.txt, pyasn1-modules, rsa
 pyparsing==2.4.7          # via -r requirements/base.txt, packaging
 pytest-aiohttp==0.3.0     # via -r requirements/base.txt, pytest-repo-health
 pytest-repo-health==1.1.1  # via -r requirements/base.txt
 pytest==6.0.1             # via -r requirements/base.txt, pytest-aiohttp, pytest-repo-health
 pyyaml==5.3.1             # via -r requirements/base.txt, pytest-repo-health
-six==1.15.0               # via -r requirements/base.txt, packaging, tox, virtualenv
+requests-oauthlib==1.3.0  # via -r requirements/base.txt, google-auth-oauthlib
+requests==2.24.0          # via -r requirements/base.txt, gspread, requests-oauthlib
+rsa==4.6                  # via -r requirements/base.txt, google-auth
+six==1.15.0               # via -r requirements/base.txt, google-auth, packaging, tox, virtualenv
 smmap==3.0.4              # via -r requirements/base.txt, gitdb
 toml==0.10.1              # via -r requirements/base.txt, pytest, tox
 tox==3.18.1               # via -r requirements/test.in
 typing-extensions==3.7.4.2  # via -r requirements/base.txt, aiohttp, yarl
-virtualenv==20.0.28       # via tox
-yarl==1.5.0               # via -r requirements/base.txt, aiohttp
+urllib3==1.25.10          # via -r requirements/base.txt, requests
+virtualenv==20.0.29       # via tox
+yarl==1.5.1               # via -r requirements/base.txt, aiohttp
 zipp==3.1.0               # via -r requirements/base.txt, importlib-metadata, importlib-resources
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -8,37 +8,50 @@ aiohttp==3.6.2            # via -r requirements/test.txt, github.py, pytest-aioh
 appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
 async-timeout==3.0.1      # via -r requirements/test.txt, aiohttp
 attrs==19.3.0             # via -r requirements/test.txt, aiohttp, pytest
-chardet==3.0.4            # via -r requirements/test.txt, aiohttp
+cachetools==4.1.1         # via -r requirements/test.txt, google-auth
+certifi==2020.6.20        # via -r requirements/test.txt, requests
+chardet==3.0.4            # via -r requirements/test.txt, aiohttp, requests
 click==7.1.2              # via -r requirements/pip-tools.txt, pip-tools
 distlib==0.3.1            # via -r requirements/test.txt, virtualenv
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 gitdb==4.0.5              # via -r requirements/test.txt, gitpython
 github.py==0.5.0          # via -r requirements/test.txt, pytest-repo-health
 gitpython==3.1.7          # via -r requirements/test.txt, pytest-repo-health
+google-auth-oauthlib==0.4.1  # via -r requirements/test.txt, gspread
+google-auth==1.20.0       # via -r requirements/test.txt, google-auth-oauthlib, gspread
+gspread==3.6.0            # via -r requirements/test.txt
 idna-ssl==1.1.0           # via -r requirements/test.txt, aiohttp
-idna==2.10                # via -r requirements/test.txt, idna-ssl, yarl
+idna==2.10                # via -r requirements/test.txt, idna-ssl, requests, yarl
 importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/test.txt, virtualenv
-iniconfig==1.0.0          # via -r requirements/test.txt, pytest
+iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 more-itertools==8.4.0     # via -r requirements/test.txt, pytest
 multidict==4.7.6          # via -r requirements/test.txt, aiohttp, yarl
+oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib
 packaging==20.4           # via -r requirements/test.txt, pytest, tox
-pip-tools==5.3.0          # via -r requirements/pip-tools.txt
+pip-tools==5.3.1          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 py==1.9.0                 # via -r requirements/test.txt, pytest, tox
+pyasn1-modules==0.2.8     # via -r requirements/test.txt, google-auth
+pyasn1==0.4.8             # via -r requirements/test.txt, pyasn1-modules, rsa
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-aiohttp==0.3.0     # via -r requirements/test.txt, pytest-repo-health
 pytest-repo-health==1.1.1  # via -r requirements/test.txt
 pytest==6.0.1             # via -r requirements/test.txt, pytest-aiohttp, pytest-repo-health
 pyyaml==5.3.1             # via -r requirements/test.txt, pytest-repo-health
-six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/test.txt, packaging, pip-tools, tox, virtualenv
+requests-oauthlib==1.3.0  # via -r requirements/test.txt, google-auth-oauthlib
+requests==2.24.0          # via -r requirements/test.txt, gspread, requests-oauthlib
+rsa==4.6                  # via -r requirements/test.txt, google-auth
+six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/test.txt, google-auth, packaging, pip-tools, tox, virtualenv
 smmap==3.0.4              # via -r requirements/test.txt, gitdb
 toml==0.10.1              # via -r requirements/test.txt, pytest, tox
 tox==3.18.1               # via -r requirements/test.txt
 typing-extensions==3.7.4.2  # via -r requirements/test.txt, aiohttp, yarl
-virtualenv==20.0.28       # via -r requirements/test.txt, tox
-yarl==1.5.0               # via -r requirements/test.txt, aiohttp
+urllib3==1.25.10          # via -r requirements/test.txt, requests
+virtualenv==20.0.29       # via -r requirements/test.txt, tox
+yarl==1.5.1               # via -r requirements/test.txt, aiohttp
 zipp==3.1.0               # via -r requirements/test.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip
+# setuptools


### PR DESCRIPTION
Added a new check to get repository ownership data from the master spreadsheet, and added `gspread` as a dependency.  The new check should be skipped unless the appropriate environment variables are set (which will only be true for the Jenkins job and some local dev environments).

It looks like some of the requirements files (like `travis.txt`) have too much in them, but I'll ticket fixing that separately.