### PR TITLE
Disable code of conduct check, refactor dependencies ARCHBOM-1383

### DIFF
--- a/repo_health/check_github.py
+++ b/repo_health/check_github.py
@@ -116,8 +116,9 @@ async def check_settings(all_results, github_repo):
     results["allows_merge_commit"] = github_repo.allows_merge_commit
     results["allows_rebase_merge"] = github_repo.allows_rebase_merge
     results["allows_squash_merge"] = github_repo.allows_squash_merge
-    coc = github_repo.code_of_conduct
-    results["code_of_conduct"] = coc.name if coc else None
+    # This causes github.py 0.5.0 to choke, newer code isn't on PyPI yet
+    # coc = github_repo.code_of_conduct
+    # results["code_of_conduct"] = coc.name if coc else None
     results["created_at"] = github_repo.created_at
     try:
         results["default_branch"] = github_repo.default_branch

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,47 +4,49 @@
 #
 #    make upgrade
 #
-aiohttp==3.6.2            # via -r requirements/quality.txt, -r requirements/travis.txt, github.py, pytest-aiohttp
-appdirs==1.4.4            # via -r requirements/quality.txt, -r requirements/travis.txt, virtualenv
+aiohttp==3.6.2            # via -r requirements/quality.txt, github.py, pytest-aiohttp
+appdirs==1.4.4            # via -r requirements/travis.txt, virtualenv
 astroid==2.3.3            # via -r requirements/quality.txt, pylint, pylint-celery
-async-timeout==3.0.1      # via -r requirements/quality.txt, -r requirements/travis.txt, aiohttp
-attrs==19.3.0             # via -r requirements/quality.txt, -r requirements/travis.txt, aiohttp, pytest
-cachetools==4.1.1         # via -r requirements/quality.txt, -r requirements/travis.txt, google-auth
+async-timeout==3.0.1      # via -r requirements/quality.txt, aiohttp
+attrs==19.3.0             # via -r requirements/quality.txt, aiohttp, pytest
+cachetools==4.1.1         # via -r requirements/quality.txt, google-auth
 certifi==2020.6.20        # via -r requirements/quality.txt, -r requirements/travis.txt, requests
 chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/travis.txt, aiohttp, requests
 click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
-click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, click-log, edx-lint, pip-tools
+click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, click-log, edx-lint, pip-tools
+codecov==2.1.8            # via -r requirements/travis.txt
+coverage==5.2.1           # via -r requirements/travis.txt, codecov
 diff-cover==3.0.1         # via -r requirements/dev.in
-distlib==0.3.1            # via -r requirements/quality.txt, -r requirements/travis.txt, virtualenv
+distlib==0.3.1            # via -r requirements/travis.txt, virtualenv
 edx-lint==1.5.0           # via -r requirements/quality.txt
-filelock==3.0.12          # via -r requirements/quality.txt, -r requirements/travis.txt, tox, virtualenv
-gitdb==4.0.5              # via -r requirements/quality.txt, -r requirements/travis.txt, gitpython
-github.py==0.5.0          # via -r requirements/quality.txt, -r requirements/travis.txt, pytest-repo-health
-gitpython==3.1.7          # via -r requirements/quality.txt, -r requirements/travis.txt, pytest-repo-health
-google-auth-oauthlib==0.4.1  # via -r requirements/quality.txt, -r requirements/travis.txt, gspread
-google-auth==1.20.1       # via -r requirements/quality.txt, -r requirements/travis.txt, google-auth-oauthlib, gspread
-gspread==3.6.0            # via -r requirements/quality.txt, -r requirements/travis.txt
-idna-ssl==1.1.0           # via -r requirements/quality.txt, -r requirements/travis.txt, aiohttp
+filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
+gitdb==4.0.5              # via -r requirements/quality.txt, gitpython
+github.py==0.5.0          # via -r requirements/quality.txt, pytest-repo-health
+gitpython==3.1.7          # via -r requirements/quality.txt, pytest-repo-health
+google-auth-oauthlib==0.4.1  # via -r requirements/quality.txt, gspread
+google-auth==1.20.1       # via -r requirements/quality.txt, google-auth-oauthlib, gspread
+gspread==3.6.0            # via -r requirements/quality.txt
+idna-ssl==1.1.0           # via -r requirements/quality.txt, aiohttp
 idna==2.10                # via -r requirements/quality.txt, -r requirements/travis.txt, idna-ssl, requests, yarl
 importlib-metadata==1.7.0  # via -r requirements/quality.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
-importlib-resources==3.0.0  # via -r requirements/quality.txt, -r requirements/travis.txt, virtualenv
+importlib-resources==3.0.0  # via -r requirements/travis.txt, virtualenv
 inflect==4.1.0            # via jinja2-pluralize
-iniconfig==1.0.1          # via -r requirements/quality.txt, -r requirements/travis.txt, pytest
+iniconfig==1.0.1          # via -r requirements/quality.txt, pytest
 isort==4.3.21             # via -r requirements/quality.txt, pylint
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via diff-cover, jinja2-pluralize
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, astroid
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, pylint
-more-itertools==8.4.0     # via -r requirements/quality.txt, -r requirements/travis.txt, pytest
-multidict==4.7.6          # via -r requirements/quality.txt, -r requirements/travis.txt, aiohttp, yarl
-oauthlib==3.1.0           # via -r requirements/quality.txt, -r requirements/travis.txt, requests-oauthlib
+more-itertools==8.4.0     # via -r requirements/quality.txt, pytest
+multidict==4.7.6          # via -r requirements/quality.txt, aiohttp, yarl
+oauthlib==3.1.0           # via -r requirements/quality.txt, requests-oauthlib
 packaging==20.4           # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
-pip-tools==5.3.1          # via -r requirements/pip-tools.txt, -r requirements/travis.txt
+pip-tools==5.3.1          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/quality.txt, -r requirements/travis.txt, diff-cover, pytest, tox
 py==1.9.0                 # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
-pyasn1-modules==0.2.8     # via -r requirements/quality.txt, -r requirements/travis.txt, google-auth
-pyasn1==0.4.8             # via -r requirements/quality.txt, -r requirements/travis.txt, pyasn1-modules, rsa
+pyasn1-modules==0.2.8     # via -r requirements/quality.txt, google-auth
+pyasn1==0.4.8             # via -r requirements/quality.txt, pyasn1-modules, rsa
 pycodestyle==2.6.0        # via -r requirements/quality.txt
 pydocstyle==5.0.2         # via -r requirements/quality.txt
 pygments==2.6.1           # via diff-cover
@@ -53,25 +55,25 @@ pylint-django==2.0.11     # via -r requirements/quality.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/quality.txt, pylint-celery, pylint-django
 pylint==2.4.4             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/quality.txt, -r requirements/travis.txt, packaging
-pytest-aiohttp==0.3.0     # via -r requirements/quality.txt, -r requirements/travis.txt, pytest-repo-health
-pytest-repo-health==1.1.1  # via -r requirements/quality.txt, -r requirements/travis.txt
-pytest==6.0.1             # via -r requirements/quality.txt, -r requirements/travis.txt, pytest-aiohttp, pytest-repo-health
-pyyaml==5.3.1             # via -r requirements/quality.txt, -r requirements/travis.txt, pytest-repo-health
-requests-oauthlib==1.3.0  # via -r requirements/quality.txt, -r requirements/travis.txt, google-auth-oauthlib
-requests==2.24.0          # via -r requirements/quality.txt, -r requirements/travis.txt, gspread, requests-oauthlib
-rsa==4.6                  # via -r requirements/quality.txt, -r requirements/travis.txt, google-auth
+pytest-aiohttp==0.3.0     # via -r requirements/quality.txt, pytest-repo-health
+pytest-repo-health==1.1.1  # via -r requirements/quality.txt
+pytest==6.0.1             # via -r requirements/quality.txt, pytest-aiohttp, pytest-repo-health
+pyyaml==5.3.1             # via -r requirements/quality.txt, pytest-repo-health
+requests-oauthlib==1.3.0  # via -r requirements/quality.txt, google-auth-oauthlib
+requests==2.24.0          # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, gspread, requests-oauthlib
+rsa==4.6                  # via -r requirements/quality.txt, google-auth
 six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, diff-cover, edx-lint, google-auth, packaging, pip-tools, tox, virtualenv
-smmap==3.0.4              # via -r requirements/quality.txt, -r requirements/travis.txt, gitdb
+smmap==3.0.4              # via -r requirements/quality.txt, gitdb
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 toml==0.10.1              # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
 tox-battery==0.6.1        # via -r requirements/dev.in
-tox==3.19.0               # via -r requirements/quality.txt, -r requirements/travis.txt, tox-battery
+tox==3.19.0               # via -r requirements/travis.txt, tox-battery
 typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
-typing-extensions==3.7.4.2  # via -r requirements/quality.txt, -r requirements/travis.txt, aiohttp, yarl
+typing-extensions==3.7.4.2  # via -r requirements/quality.txt, aiohttp, yarl
 urllib3==1.25.10          # via -r requirements/quality.txt, -r requirements/travis.txt, requests
-virtualenv==20.0.30       # via -r requirements/quality.txt, -r requirements/travis.txt, tox
+virtualenv==20.0.30       # via -r requirements/travis.txt, tox
 wrapt==1.11.2             # via -r requirements/quality.txt, astroid
-yarl==1.5.1               # via -r requirements/quality.txt, -r requirements/travis.txt, aiohttp
+yarl==1.5.1               # via -r requirements/quality.txt, aiohttp
 zipp==3.1.0               # via -r requirements/quality.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,7 +6,6 @@
 #
 aiohttp==3.6.2            # via -r requirements/test.txt, github.py, pytest-aiohttp
 alabaster==0.7.12         # via sphinx
-appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
 async-timeout==3.0.1      # via -r requirements/test.txt, aiohttp
 attrs==19.3.0             # via -r requirements/test.txt, aiohttp, pytest
 babel==2.8.0              # via sphinx
@@ -14,11 +13,9 @@ bleach==3.1.5             # via readme-renderer
 cachetools==4.1.1         # via -r requirements/test.txt, google-auth
 certifi==2020.6.20        # via -r requirements/test.txt, requests
 chardet==3.0.4            # via -r requirements/test.txt, aiohttp, doc8, requests
-distlib==0.3.1            # via -r requirements/test.txt, virtualenv
 doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
-filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 gitdb==4.0.5              # via -r requirements/test.txt, gitpython
 github.py==0.5.0          # via -r requirements/test.txt, pytest-repo-health
 gitpython==3.1.7          # via -r requirements/test.txt, pytest-repo-health
@@ -28,18 +25,17 @@ gspread==3.6.0            # via -r requirements/test.txt
 idna-ssl==1.1.0           # via -r requirements/test.txt, aiohttp
 idna==2.10                # via -r requirements/test.txt, idna-ssl, requests, yarl
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest, stevedore, tox, virtualenv
-importlib-resources==3.0.0  # via -r requirements/test.txt, virtualenv
+importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest, stevedore
 iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 jinja2==2.11.2            # via sphinx
 markupsafe==1.1.1         # via jinja2
 more-itertools==8.4.0     # via -r requirements/test.txt, pytest
 multidict==4.7.6          # via -r requirements/test.txt, aiohttp, yarl
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib
-packaging==20.4           # via -r requirements/test.txt, bleach, pytest, sphinx, tox
+packaging==20.4           # via -r requirements/test.txt, bleach, pytest, sphinx
 pbr==5.4.5                # via stevedore
-pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
-py==1.9.0                 # via -r requirements/test.txt, pytest, tox
+pluggy==0.13.1            # via -r requirements/test.txt, pytest
+py==1.9.0                 # via -r requirements/test.txt, pytest
 pyasn1-modules==0.2.8     # via -r requirements/test.txt, google-auth
 pyasn1==0.4.8             # via -r requirements/test.txt, pyasn1-modules, rsa
 pygments==2.6.1           # via doc8, readme-renderer, sphinx
@@ -54,10 +50,10 @@ requests-oauthlib==1.3.0  # via -r requirements/test.txt, google-auth-oauthlib
 requests==2.24.0          # via -r requirements/test.txt, gspread, requests-oauthlib, sphinx
 restructuredtext-lint==1.3.1  # via doc8
 rsa==4.6                  # via -r requirements/test.txt, google-auth
-six==1.15.0               # via -r requirements/test.txt, bleach, doc8, edx-sphinx-theme, google-auth, packaging, readme-renderer, tox, virtualenv
+six==1.15.0               # via -r requirements/test.txt, bleach, doc8, edx-sphinx-theme, google-auth, packaging, readme-renderer
 smmap==3.0.4              # via -r requirements/test.txt, gitdb
 snowballstemmer==2.0.0    # via sphinx
-sphinx==3.1.2             # via -r requirements/doc.in, edx-sphinx-theme
+sphinx==3.2.0             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
@@ -65,14 +61,12 @@ sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 stevedore==3.2.0          # via doc8
-toml==0.10.1              # via -r requirements/test.txt, pytest, tox
-tox==3.19.0               # via -r requirements/test.txt
+toml==0.10.1              # via -r requirements/test.txt, pytest
 typing-extensions==3.7.4.2  # via -r requirements/test.txt, aiohttp, yarl
 urllib3==1.25.10          # via -r requirements/test.txt, requests
-virtualenv==20.0.30       # via -r requirements/test.txt, tox
 webencodings==0.5.1       # via bleach
 yarl==1.5.1               # via -r requirements/test.txt, aiohttp
-zipp==3.1.0               # via -r requirements/test.txt, importlib-metadata, importlib-resources
+zipp==3.1.0               # via -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -5,7 +5,6 @@
 #    make upgrade
 #
 aiohttp==3.6.2            # via -r requirements/test.txt, github.py, pytest-aiohttp
-appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
 astroid==2.3.3            # via pylint, pylint-celery
 async-timeout==3.0.1      # via -r requirements/test.txt, aiohttp
 attrs==19.3.0             # via -r requirements/test.txt, aiohttp, pytest
@@ -14,9 +13,7 @@ certifi==2020.6.20        # via -r requirements/test.txt, requests
 chardet==3.0.4            # via -r requirements/test.txt, aiohttp, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
-distlib==0.3.1            # via -r requirements/test.txt, virtualenv
 edx-lint==1.5.0           # via -r requirements/quality.in
-filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 gitdb==4.0.5              # via -r requirements/test.txt, gitpython
 github.py==0.5.0          # via -r requirements/test.txt, pytest-repo-health
 gitpython==3.1.7          # via -r requirements/test.txt, pytest-repo-health
@@ -25,8 +22,7 @@ google-auth==1.20.1       # via -r requirements/test.txt, google-auth-oauthlib, 
 gspread==3.6.0            # via -r requirements/test.txt
 idna-ssl==1.1.0           # via -r requirements/test.txt, aiohttp
 idna==2.10                # via -r requirements/test.txt, idna-ssl, requests, yarl
-importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest, tox, virtualenv
-importlib-resources==3.0.0  # via -r requirements/test.txt, virtualenv
+importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest
 iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/quality.in, pylint
 lazy-object-proxy==1.4.3  # via astroid
@@ -34,9 +30,9 @@ mccabe==0.6.1             # via pylint
 more-itertools==8.4.0     # via -r requirements/test.txt, pytest
 multidict==4.7.6          # via -r requirements/test.txt, aiohttp, yarl
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib
-packaging==20.4           # via -r requirements/test.txt, pytest, tox
-pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
-py==1.9.0                 # via -r requirements/test.txt, pytest, tox
+packaging==20.4           # via -r requirements/test.txt, pytest
+pluggy==0.13.1            # via -r requirements/test.txt, pytest
+py==1.9.0                 # via -r requirements/test.txt, pytest
 pyasn1-modules==0.2.8     # via -r requirements/test.txt, google-auth
 pyasn1==0.4.8             # via -r requirements/test.txt, pyasn1-modules, rsa
 pycodestyle==2.6.0        # via -r requirements/quality.in
@@ -53,18 +49,16 @@ pyyaml==5.3.1             # via -r requirements/test.txt, pytest-repo-health
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, google-auth-oauthlib
 requests==2.24.0          # via -r requirements/test.txt, gspread, requests-oauthlib
 rsa==4.6                  # via -r requirements/test.txt, google-auth
-six==1.15.0               # via -r requirements/test.txt, astroid, edx-lint, google-auth, packaging, tox, virtualenv
+six==1.15.0               # via -r requirements/test.txt, astroid, edx-lint, google-auth, packaging
 smmap==3.0.4              # via -r requirements/test.txt, gitdb
 snowballstemmer==2.0.0    # via pydocstyle
-toml==0.10.1              # via -r requirements/test.txt, pytest, tox
-tox==3.19.0               # via -r requirements/test.txt
+toml==0.10.1              # via -r requirements/test.txt, pytest
 typed-ast==1.4.1          # via astroid
 typing-extensions==3.7.4.2  # via -r requirements/test.txt, aiohttp, yarl
 urllib3==1.25.10          # via -r requirements/test.txt, requests
-virtualenv==20.0.30       # via -r requirements/test.txt, tox
 wrapt==1.11.2             # via astroid
 yarl==1.5.1               # via -r requirements/test.txt, aiohttp
-zipp==3.1.0               # via -r requirements/test.txt, importlib-metadata, importlib-resources
+zipp==3.1.0               # via -r requirements/test.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -2,6 +2,3 @@
 -c constraints.txt
 
 -r base.txt               # Core dependencies for this package
-
-tox                       # To run python tests in multiple environments
-

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,14 +5,11 @@
 #    make upgrade
 #
 aiohttp==3.6.2            # via -r requirements/base.txt, github.py, pytest-aiohttp
-appdirs==1.4.4            # via virtualenv
 async-timeout==3.0.1      # via -r requirements/base.txt, aiohttp
 attrs==19.3.0             # via -r requirements/base.txt, aiohttp, pytest
 cachetools==4.1.1         # via -r requirements/base.txt, google-auth
 certifi==2020.6.20        # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, aiohttp, requests
-distlib==0.3.1            # via virtualenv
-filelock==3.0.12          # via tox, virtualenv
 gitdb==4.0.5              # via -r requirements/base.txt, gitpython
 github.py==0.5.0          # via -r requirements/base.txt, pytest-repo-health
 gitpython==3.1.7          # via -r requirements/base.txt, pytest-repo-health
@@ -21,15 +18,14 @@ google-auth==1.20.1       # via -r requirements/base.txt, google-auth-oauthlib, 
 gspread==3.6.0            # via -r requirements/base.txt
 idna-ssl==1.1.0           # via -r requirements/base.txt, aiohttp
 idna==2.10                # via -r requirements/base.txt, idna-ssl, requests, yarl
-importlib-metadata==1.7.0  # via -r requirements/base.txt, pluggy, pytest, tox, virtualenv
-importlib-resources==3.0.0  # via virtualenv
+importlib-metadata==1.7.0  # via -r requirements/base.txt, pluggy, pytest
 iniconfig==1.0.1          # via -r requirements/base.txt, pytest
 more-itertools==8.4.0     # via -r requirements/base.txt, pytest
 multidict==4.7.6          # via -r requirements/base.txt, aiohttp, yarl
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib
-packaging==20.4           # via -r requirements/base.txt, pytest, tox
-pluggy==0.13.1            # via -r requirements/base.txt, pytest, tox
-py==1.9.0                 # via -r requirements/base.txt, pytest, tox
+packaging==20.4           # via -r requirements/base.txt, pytest
+pluggy==0.13.1            # via -r requirements/base.txt, pytest
+py==1.9.0                 # via -r requirements/base.txt, pytest
 pyasn1-modules==0.2.8     # via -r requirements/base.txt, google-auth
 pyasn1==0.4.8             # via -r requirements/base.txt, pyasn1-modules, rsa
 pyparsing==2.4.7          # via -r requirements/base.txt, packaging
@@ -40,15 +36,13 @@ pyyaml==5.3.1             # via -r requirements/base.txt, pytest-repo-health
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, google-auth-oauthlib
 requests==2.24.0          # via -r requirements/base.txt, gspread, requests-oauthlib
 rsa==4.6                  # via -r requirements/base.txt, google-auth
-six==1.15.0               # via -r requirements/base.txt, google-auth, packaging, tox, virtualenv
+six==1.15.0               # via -r requirements/base.txt, google-auth, packaging
 smmap==3.0.4              # via -r requirements/base.txt, gitdb
-toml==0.10.1              # via -r requirements/base.txt, pytest, tox
-tox==3.19.0               # via -r requirements/test.in
+toml==0.10.1              # via -r requirements/base.txt, pytest
 typing-extensions==3.7.4.2  # via -r requirements/base.txt, aiohttp, yarl
 urllib3==1.25.10          # via -r requirements/base.txt, requests
-virtualenv==20.0.30       # via tox
 yarl==1.5.1               # via -r requirements/base.txt, aiohttp
-zipp==3.1.0               # via -r requirements/base.txt, importlib-metadata, importlib-resources
+zipp==3.1.0               # via -r requirements/base.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/travis.in
+++ b/requirements/travis.in
@@ -1,2 +1,5 @@
--r pip-tools.txt          # pip-tools and its dependencies, for managing requirements files
--r test.txt
+# Requirements for running tests in Travis
+-c constraints.txt
+
+codecov                   # Code coverage reporting
+tox                       # Virtualenv management for tests

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -4,54 +4,24 @@
 #
 #    make upgrade
 #
-aiohttp==3.6.2            # via -r requirements/test.txt, github.py, pytest-aiohttp
-appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
-async-timeout==3.0.1      # via -r requirements/test.txt, aiohttp
-attrs==19.3.0             # via -r requirements/test.txt, aiohttp, pytest
-cachetools==4.1.1         # via -r requirements/test.txt, google-auth
-certifi==2020.6.20        # via -r requirements/test.txt, requests
-chardet==3.0.4            # via -r requirements/test.txt, aiohttp, requests
-click==7.1.2              # via -r requirements/pip-tools.txt, pip-tools
-distlib==0.3.1            # via -r requirements/test.txt, virtualenv
-filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
-gitdb==4.0.5              # via -r requirements/test.txt, gitpython
-github.py==0.5.0          # via -r requirements/test.txt, pytest-repo-health
-gitpython==3.1.7          # via -r requirements/test.txt, pytest-repo-health
-google-auth-oauthlib==0.4.1  # via -r requirements/test.txt, gspread
-google-auth==1.20.1       # via -r requirements/test.txt, google-auth-oauthlib, gspread
-gspread==3.6.0            # via -r requirements/test.txt
-idna-ssl==1.1.0           # via -r requirements/test.txt, aiohttp
-idna==2.10                # via -r requirements/test.txt, idna-ssl, requests, yarl
-importlib-metadata==1.7.0  # via -r requirements/test.txt, pluggy, pytest, tox, virtualenv
-importlib-resources==3.0.0  # via -r requirements/test.txt, virtualenv
-iniconfig==1.0.1          # via -r requirements/test.txt, pytest
-more-itertools==8.4.0     # via -r requirements/test.txt, pytest
-multidict==4.7.6          # via -r requirements/test.txt, aiohttp, yarl
-oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib
-packaging==20.4           # via -r requirements/test.txt, pytest, tox
-pip-tools==5.3.1          # via -r requirements/pip-tools.txt
-pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
-py==1.9.0                 # via -r requirements/test.txt, pytest, tox
-pyasn1-modules==0.2.8     # via -r requirements/test.txt, google-auth
-pyasn1==0.4.8             # via -r requirements/test.txt, pyasn1-modules, rsa
-pyparsing==2.4.7          # via -r requirements/test.txt, packaging
-pytest-aiohttp==0.3.0     # via -r requirements/test.txt, pytest-repo-health
-pytest-repo-health==1.1.1  # via -r requirements/test.txt
-pytest==6.0.1             # via -r requirements/test.txt, pytest-aiohttp, pytest-repo-health
-pyyaml==5.3.1             # via -r requirements/test.txt, pytest-repo-health
-requests-oauthlib==1.3.0  # via -r requirements/test.txt, google-auth-oauthlib
-requests==2.24.0          # via -r requirements/test.txt, gspread, requests-oauthlib
-rsa==4.6                  # via -r requirements/test.txt, google-auth
-six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/test.txt, google-auth, packaging, pip-tools, tox, virtualenv
-smmap==3.0.4              # via -r requirements/test.txt, gitdb
-toml==0.10.1              # via -r requirements/test.txt, pytest, tox
-tox==3.19.0               # via -r requirements/test.txt
-typing-extensions==3.7.4.2  # via -r requirements/test.txt, aiohttp, yarl
-urllib3==1.25.10          # via -r requirements/test.txt, requests
-virtualenv==20.0.30       # via -r requirements/test.txt, tox
-yarl==1.5.1               # via -r requirements/test.txt, aiohttp
-zipp==3.1.0               # via -r requirements/test.txt, importlib-metadata, importlib-resources
-
-# The following packages are considered to be unsafe in a requirements file:
-# pip
-# setuptools
+appdirs==1.4.4            # via virtualenv
+certifi==2020.6.20        # via requests
+chardet==3.0.4            # via requests
+codecov==2.1.8            # via -r requirements/travis.in
+coverage==5.2.1           # via codecov
+distlib==0.3.1            # via virtualenv
+filelock==3.0.12          # via tox, virtualenv
+idna==2.10                # via requests
+importlib-metadata==1.7.0  # via pluggy, tox, virtualenv
+importlib-resources==3.0.0  # via virtualenv
+packaging==20.4           # via tox
+pluggy==0.13.1            # via tox
+py==1.9.0                 # via tox
+pyparsing==2.4.7          # via packaging
+requests==2.24.0          # via codecov
+six==1.15.0               # via packaging, tox, virtualenv
+toml==0.10.1              # via tox
+tox==3.19.0               # via -r requirements/travis.in
+urllib3==1.25.10          # via requests
+virtualenv==20.0.30       # via tox
+zipp==3.1.0               # via importlib-metadata, importlib-resources

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ match-dir = (?!migrations)
 [testenv:docs]
 setenv =
     PYTHONPATH = {toxinidir}
-whitelist_externals =
+allowlist_externals =
     make
     rm
 deps =


### PR DESCRIPTION
Disable the code of conduct GitHub check, since that breaks in github.py 0.5.0 if one is actually present (I think that's fixed on master).  Also refactored the requirements files a little to avoid including dependencies in contexts where they aren't needed.  Finally, updated `tox.ini` to avoid using a deprecated setting name.