### PR TITLE
Finish ownership and code of conduct fixes ARCHBOM-1383

### DIFF
--- a/repo_health/check_github.py
+++ b/repo_health/check_github.py
@@ -116,9 +116,8 @@ async def check_settings(all_results, github_repo):
     results["allows_merge_commit"] = github_repo.allows_merge_commit
     results["allows_rebase_merge"] = github_repo.allows_rebase_merge
     results["allows_squash_merge"] = github_repo.allows_squash_merge
-    # This causes github.py 0.5.0 to choke, newer code isn't on PyPI yet
-    # coc = github_repo.code_of_conduct
-    # results["code_of_conduct"] = coc.name if coc else None
+    coc = github_repo.code_of_conduct
+    results["code_of_conduct"] = coc.name if coc else None
     results["created_at"] = github_repo.created_at
     try:
         results["default_branch"] = github_repo.default_branch

--- a/repo_health/check_openedx_yaml.py
+++ b/repo_health/check_openedx_yaml.py
@@ -6,13 +6,19 @@ import os
 import pytest
 import yaml
 
-from pytest_repo_health import add_key_to_metadata
+from pytest_repo_health import add_key_to_metadata, health_metadata
 
 from repo_health import get_file_content
 
 # Decision: require openedx.yaml to be parsable
 
 module_dict_key = "openedx_yaml"
+output_keys = {
+    "oep-2": "Indicates compliance with OEP-2: standards for how openedx.yaml is structured",
+    "oep-7": "Indicates compliance with OEP-7: has repo migrated to python 3?",
+    "oep-18": "Indicates compliance with OEP-18: standards for make upgrade target and requirement files",
+    "oep-30": "Indicates compliance with OEP-30: Personally Identifiable Information Markup and Auditing",
+}
 
 
 @pytest.fixture(name='openedx_yaml')
@@ -48,16 +54,6 @@ def check_yaml_parsable(openedx_yaml, all_results):
         all_results[module_dict_key]["parsable"] = False
 
 
-@add_key_to_metadata((module_dict_key, "owner"))
-def check_owner(parsed_data, all_results):
-    """
-    The name of official owner of repo(the one reponsible for maintenance)
-    """
-    all_results[module_dict_key]["owner"] = None
-    if "owner" in parsed_data.keys():
-        all_results[module_dict_key]["owner"] = parsed_data["owner"]
-
-
 @pytest.fixture(name='oeps')
 def fixture_oeps(parsed_data):
     if "oeps" in parsed_data:
@@ -65,49 +61,16 @@ def fixture_oeps(parsed_data):
     return {}
 
 
-@add_key_to_metadata((module_dict_key, "oep_2"))
-def check_oep_2(oeps, all_results):
+@health_metadata(
+    [module_dict_key],
+    output_keys
+)
+def check_oeps(oeps, all_results):
     """
-    Indicated compliance with OEP-2: standards for how openedx.yaml is structured
+    Check compliance with OEPs of particular interest
     """
-    oep_name = "oep-2"
-    if oep_name in oeps:
-        all_results[module_dict_key][oep_name] = oeps[oep_name]
-    else:
-        all_results[module_dict_key][oep_name] = False
-
-
-@add_key_to_metadata((module_dict_key, "oep_2"))
-def check_oep_7(oeps, all_results):
-    """
-    Indicates compliance with OEP-7: has repo migrated to python 3
-    """
-    oep_name = "oep-7"
-    if oep_name in oeps:
-        all_results[module_dict_key][oep_name] = oeps[oep_name]
-    else:
-        all_results[module_dict_key][oep_name] = False
-
-
-@add_key_to_metadata((module_dict_key, "oep_18"))
-def check_oep_18(oeps, all_results):
-    """
-    Indicates compliance with OEP-18: standards for make upgrade target and requirement files
-    """
-    oep_name = "oep-18"
-    if oep_name in oeps:
-        all_results[module_dict_key][oep_name] = oeps[oep_name]
-    else:
-        all_results[module_dict_key][oep_name] = False
-
-
-@add_key_to_metadata((module_dict_key, "oep_30"))
-def check_oep_30(oeps, all_results):
-    """
-    Indicates compliance with OEP-30: Personally Identifiable Information Markup and Auditing
-    """
-    oep_name = "oep-30"
-    if oep_name in oeps:
-        all_results[module_dict_key][oep_name] = oeps[oep_name]
-    else:
-        all_results[module_dict_key][oep_name] = False
+    for oep_name, _ in output_keys.items():
+        if oep_name in oeps:
+            all_results[module_dict_key][oep_name] = oeps[oep_name]
+        else:
+            all_results[module_dict_key][oep_name] = False

--- a/repo_health_dashboard/configuration.yaml
+++ b/repo_health_dashboard/configuration.yaml
@@ -1,6 +1,6 @@
 main:
     check_order:
-        - openedx_yaml.owner
+        - ownership.squad
         - makefile.upgrade
     key_aliases:
         tox_ini.has_section.tox: tox_tox_section
@@ -13,5 +13,5 @@ python_3:
     subset: true
     check_order:
         - openedx_yaml.oep-2
-        - openedx_yaml.owner
+        - ownership.squad
         - travis_yml.python_versions

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,5 +1,6 @@
 # Core requirements for using this application
 -c constraints.txt
+-r github.in
 
 gspread                    # Access information from Google Sheets (the ownership spreadsheet)
 pyyaml                     # Read and write YAML files

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ cachetools==4.1.1         # via google-auth
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via aiohttp, requests
 gitdb==4.0.5              # via gitpython
-github.py==0.5.0          # via pytest-repo-health
+git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140  # via -r requirements/github.in
 gitpython==3.1.7          # via pytest-repo-health
 google-auth-oauthlib==0.4.1  # via gspread
 google-auth==1.20.1       # via google-auth-oauthlib, gspread
@@ -30,7 +30,7 @@ pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
 pyparsing==2.4.7          # via packaging
 pytest-aiohttp==0.3.0     # via pytest-repo-health
-pytest-repo-health==1.1.1  # via -r requirements/base.in
+pytest-repo-health==2.0.1  # via -r requirements/base.in
 pytest==6.0.1             # via pytest-aiohttp, pytest-repo-health
 pyyaml==5.3.1             # via -r requirements/base.in, pytest-repo-health
 requests-oauthlib==1.3.0  # via google-auth-oauthlib

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,7 +21,7 @@ distlib==0.3.1            # via -r requirements/travis.txt, virtualenv
 edx-lint==1.5.0           # via -r requirements/quality.txt
 filelock==3.0.12          # via -r requirements/travis.txt, tox, virtualenv
 gitdb==4.0.5              # via -r requirements/quality.txt, gitpython
-github.py==0.5.0          # via -r requirements/quality.txt, pytest-repo-health
+git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140  # via -r requirements/quality.txt
 gitpython==3.1.7          # via -r requirements/quality.txt, pytest-repo-health
 google-auth-oauthlib==0.4.1  # via -r requirements/quality.txt, gspread
 google-auth==1.20.1       # via -r requirements/quality.txt, google-auth-oauthlib, gspread
@@ -56,7 +56,7 @@ pylint-plugin-utils==0.6  # via -r requirements/quality.txt, pylint-celery, pyli
 pylint==2.4.4             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/quality.txt, -r requirements/travis.txt, packaging
 pytest-aiohttp==0.3.0     # via -r requirements/quality.txt, pytest-repo-health
-pytest-repo-health==1.1.1  # via -r requirements/quality.txt
+pytest-repo-health==2.0.1  # via -r requirements/quality.txt
 pytest==6.0.1             # via -r requirements/quality.txt, pytest-aiohttp, pytest-repo-health
 pyyaml==5.3.1             # via -r requirements/quality.txt, pytest-repo-health
 requests-oauthlib==1.3.0  # via -r requirements/quality.txt, google-auth-oauthlib

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -17,7 +17,7 @@ doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
 gitdb==4.0.5              # via -r requirements/test.txt, gitpython
-github.py==0.5.0          # via -r requirements/test.txt, pytest-repo-health
+git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140  # via -r requirements/test.txt
 gitpython==3.1.7          # via -r requirements/test.txt, pytest-repo-health
 google-auth-oauthlib==0.4.1  # via -r requirements/test.txt, gspread
 google-auth==1.20.1       # via -r requirements/test.txt, google-auth-oauthlib, gspread
@@ -41,7 +41,7 @@ pyasn1==0.4.8             # via -r requirements/test.txt, pyasn1-modules, rsa
 pygments==2.6.1           # via doc8, readme-renderer, sphinx
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-aiohttp==0.3.0     # via -r requirements/test.txt, pytest-repo-health
-pytest-repo-health==1.1.1  # via -r requirements/test.txt
+pytest-repo-health==2.0.1  # via -r requirements/test.txt
 pytest==6.0.1             # via -r requirements/test.txt, pytest-aiohttp, pytest-repo-health
 pytz==2020.1              # via babel
 pyyaml==5.3.1             # via -r requirements/test.txt, pytest-repo-health

--- a/requirements/github.in
+++ b/requirements/github.in
@@ -1,0 +1,57 @@
+# DON'T JUST ADD NEW DEPENDENCIES!!!
+#
+# If you open a pull request that adds a new dependency, you should:
+#   * verify that the dependency has a license compatible with AGPLv3
+#   * confirm that it has no system requirements beyond what we already install
+#   * run "make upgrade" to update the detailed requirements files
+#
+# Do *NOT* install Python packages from GitHub unless it's absolutely necessary!
+# "I don't have time to add automatic Travis upload to PyPI." is *not* an
+# acceptable excuse. Non-wheel module installations slow down the dev/building process.
+# Travis/PyPI instructions are here:
+# https://openedx.atlassian.net/wiki/spaces/OpenOPS/pages/41911049/Publishing+a+Package+to+PyPI+using+Travis
+#
+# A correct GitHub reference looks like this:
+#
+#   git+https://github.com/OWNER/REPO-NAME.git@TAG-OR-SHA#egg=DIST-NAME==VERSION
+#
+# For example:
+#
+#   git+https://github.com/edx/edx-lint.git@v0.3.2#egg=edx_lint==0.3.2
+#
+# where:
+#
+#   OWNER = edx
+#   REPO-NAME = edx-lint
+#   TAG-OR-SHA = v0.3.2
+#   DIST-NAME = edx_lint
+#   VERSION = 0.3.2
+#
+#
+# Rules to follow (even though many URLs here don't follow them!):
+#
+#   * Don't leave out any of these pieces.
+#
+#   * TAG-OR-SHA is the specific commit to install.  It must be a git tag,
+#     or a git SHA commit hash.  Don't use branch names here.  If OWNER is
+#     not an edX organization, then it must be a SHA.  If you use a SHA,
+#     please make sure there is a tag associated with it, so the commit can't
+#     be lost during rebase.
+#
+#   * DIST-NAME is the distribution name, the same name you'd use in a
+#     "pip install" command.  It might be different than REPO-NAME. It must
+#     be the same as the `name="DIST-NAME"` value in the repo's setup.py.
+#
+#   * VERSION might not be the same as TAG-OR-SHA, but if the tag names the
+#     version, please make it match the VERSION, but with a "v" prefix.
+#     VERSION must be the same as the `version="VERSION"` value in the repo's
+#     setup.py.  An alternative is to use 0.0 as VERSION: this forces pip to
+#     re-install the package each time, and can be useful when working with two
+#     repos before picking a version number. Don't use 0.0 on master, only for
+#     tight-loop work in progress.
+
+
+# Python libraries to install directly from github
+
+# The PyPI release chokes on parsing a repo's code of conduct
+git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -15,7 +15,7 @@ click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, edx-lint
 edx-lint==1.5.0           # via -r requirements/quality.in
 gitdb==4.0.5              # via -r requirements/test.txt, gitpython
-github.py==0.5.0          # via -r requirements/test.txt, pytest-repo-health
+git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140  # via -r requirements/test.txt
 gitpython==3.1.7          # via -r requirements/test.txt, pytest-repo-health
 google-auth-oauthlib==0.4.1  # via -r requirements/test.txt, gspread
 google-auth==1.20.1       # via -r requirements/test.txt, google-auth-oauthlib, gspread
@@ -43,7 +43,7 @@ pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-aiohttp==0.3.0     # via -r requirements/test.txt, pytest-repo-health
-pytest-repo-health==1.1.1  # via -r requirements/test.txt
+pytest-repo-health==2.0.1  # via -r requirements/test.txt
 pytest==6.0.1             # via -r requirements/test.txt, pytest-aiohttp, pytest-repo-health
 pyyaml==5.3.1             # via -r requirements/test.txt, pytest-repo-health
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, google-auth-oauthlib

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,7 +11,7 @@ cachetools==4.1.1         # via -r requirements/base.txt, google-auth
 certifi==2020.6.20        # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, aiohttp, requests
 gitdb==4.0.5              # via -r requirements/base.txt, gitpython
-github.py==0.5.0          # via -r requirements/base.txt, pytest-repo-health
+git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140  # via -r requirements/base.txt
 gitpython==3.1.7          # via -r requirements/base.txt, pytest-repo-health
 google-auth-oauthlib==0.4.1  # via -r requirements/base.txt, gspread
 google-auth==1.20.1       # via -r requirements/base.txt, google-auth-oauthlib, gspread
@@ -30,7 +30,7 @@ pyasn1-modules==0.2.8     # via -r requirements/base.txt, google-auth
 pyasn1==0.4.8             # via -r requirements/base.txt, pyasn1-modules, rsa
 pyparsing==2.4.7          # via -r requirements/base.txt, packaging
 pytest-aiohttp==0.3.0     # via -r requirements/base.txt, pytest-repo-health
-pytest-repo-health==1.1.1  # via -r requirements/base.txt
+pytest-repo-health==2.0.1  # via -r requirements/base.txt
 pytest==6.0.1             # via -r requirements/base.txt, pytest-aiohttp, pytest-repo-health
 pyyaml==5.3.1             # via -r requirements/base.txt, pytest-repo-health
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, google-auth-oauthlib


### PR DESCRIPTION
This should get the updated repo health dashboard fully working again:

* Upgrades `github.py` to fix code of conduct processing
* Upgrades `pytest-repo-health` to facilitate the above upgrade and fix handling of repos with a period in their name
* Removes the openedx.yaml owner check, replaces it in the dashboard config with the squad data from the ownership spreadsheet
* Streamlines checks for compliance with specific OEPs