### PR TITLE
Prune or fix assorted fields

### DIFF
--- a/repo_health/check_github.py
+++ b/repo_health/check_github.py
@@ -37,16 +37,10 @@ query fetch_repository_languages ($repository_id: ID!, $cursor: String=null) {
 LANGUAGES = [
     "css",
     "dockerfile",
-    "go",
-    "groovy",
     "html",
-    "java",
     "javascript",
     "makefile",
-    "objective-c",
-    "php",
     "python",
-    "ruby",
     "shell",
 ]
 
@@ -167,8 +161,8 @@ async def check_languages(all_results, github_repo):
         pytest.skip("There was an error fetching data from GitHub")
     results = all_results["language_bytes"]
     languages = await fetch_languages(github_repo)
-    for language, size in languages.items():
-        results[language] = size
     for language in LANGUAGES:
-        if language not in languages:
+        if language in languages:
+            results[language] = languages[language]
+        else:
             results[language] = 0

--- a/repo_health/check_openedx_yaml.py
+++ b/repo_health/check_openedx_yaml.py
@@ -70,7 +70,11 @@ def check_oeps(oeps, all_results):
     Check compliance with OEPs of particular interest
     """
     for oep_name, _ in output_keys.items():
+        value = False
         if oep_name in oeps:
-            all_results[module_dict_key][oep_name] = oeps[oep_name]
-        else:
-            all_results[module_dict_key][oep_name] = False
+            oep = oeps[oep_name]
+            if isinstance(oep, bool):
+                value = oep
+            elif "state" in oep:
+                value = oep["state"]
+        all_results[module_dict_key][oep_name] = value

--- a/repo_health/check_ownership.py
+++ b/repo_health/check_ownership.py
@@ -68,5 +68,3 @@ def check_ownership(all_results, git_origin_url):
         results["theme"] = row["owner.theme"]
         results["squad"] = row["owner.squad"]
         results["priority"] = row["owner.priority"]
-        results["description"] = row["Description"]
-        results['notes'] = row["Notes"]

--- a/repo_health/check_tox_ini.py
+++ b/repo_health/check_tox_ini.py
@@ -5,7 +5,7 @@ import os
 import re
 
 import pytest
-from pytest_repo_health import health_metadata
+from pytest_repo_health import add_key_to_metadata, health_metadata
 from repo_health import get_file_content
 
 module_dict_key = "tox_ini"
@@ -29,9 +29,9 @@ def fixture_tox_ini(repo_path):
 )
 def check_has_sections(tox_ini, all_results):
     """
-    Test to check if makefile has an upgrade target
+    Test to check if tox.ini has all the standard sections
     """
-    required_sections = [r"tox", r"testenv", r"testenv:quality", r"whitelist_externals"]
+    required_sections = [r"tox", r"testenv", r"testenv:quality"]
     all_results[module_dict_key]["has_section"] = {}
     for section in required_sections:
         regex_pattern = r"[" + section + r"]"
@@ -39,3 +39,12 @@ def check_has_sections(tox_ini, all_results):
         all_results[module_dict_key]["has_section"][section] = False
         if match is not None:
             all_results[module_dict_key]["has_section"][section] = True
+
+
+@add_key_to_metadata((module_dict_key, "uses_whitelist_externals"))
+def check_whitelist_externals(tox_ini, all_results):
+    """
+    Does tox.ini still use the deprecated "whitelist_externals" setting
+    (should be replaced with "allowlist_externals")
+    """
+    all_results[module_dict_key]["uses_whitelist_externals"] = "whitelist_externals" in tox_ini

--- a/repo_health/check_travis_yml.py
+++ b/repo_health/check_travis_yml.py
@@ -70,8 +70,9 @@ def fixture_python_version(parsed_data_travis):
     if python_versions:
         python_versions = sorted(python_versions, key=str)
     else:
-        python_versions = set()
+        python_versions = []
     return python_versions
+
 
 @add_key_to_metadata((module_dict_key, "py38_tests"))
 def check_has_tests_with_py38(python_versions_in_travis, all_results):

--- a/repo_health_dashboard/configuration.yaml
+++ b/repo_health_dashboard/configuration.yaml
@@ -1,6 +1,8 @@
 main:
     check_order:
+        - ownership.theme
         - ownership.squad
+        - ownership.priority
         - makefile.upgrade
     key_aliases:
         tox_ini.has_section.tox: tox_tox_section
@@ -13,5 +15,6 @@ python_3:
     subset: true
     check_order:
         - openedx_yaml.oep-2
+        - ownership.theme
         - ownership.squad
         - travis_yml.python_versions


### PR DESCRIPTION
Removed or fixed an assortment of fields to make the output a little easier to work with (and more correct in some cases):

* Only show the number of bytes for 7 specific languages of interest, down from 39 currently on the dashboard (usually only for 1-3 repos each)
* Just show True or False for each OEP of interest, correctly accounting for each way of declaring it and omitting the rarely used `applicable` and `reason` fields
* Omit the description and notes from the ownership spreadsheet, since they're rarely used and require a lot of column width to read the few that have been set.
* Fix the tox.ini check for usage of the deprecated `whitelist_externals` setting
* Fix the check for Python versions used in Travis to match the one for setup.py when none are present
* Move all the remaining ownership fields near the start of the dashboard