### PR TITLE
Checking requirements folder existence

### DIFF
--- a/repo_health/check_dependencies.py
+++ b/repo_health/check_dependencies.py
@@ -1,0 +1,62 @@
+"""
+ Checks which are the dependencies of the repo
+"""
+import re
+import glob
+import os
+
+import pytest
+from pytest_repo_health import health_metadata
+from repo_health import get_file_lines
+
+module_dict_key = "dependencies"
+
+
+@pytest.fixture(name='dependencies')
+def fixture_req_packages(repo_path):
+    """
+    Fixture containing the text content of req_files
+    """
+    pypi_packages = []
+    github_packages = []
+    files = glob.glob(os.path.join(repo_path, "requirements/**/*.txt"), recursive=True)
+    constraints_files = ("constraints.txt", "pins.txt")
+    requirement_files = [file for file in files if not file.endswith(constraints_files)]
+    for file_path in requirement_files:
+        lines = get_file_lines(file_path)
+        stripped_lines = [re.sub(r' +#.*', "", line).replace('-e ', "")
+                          for line in lines if line and not line.startswith("#")]
+        github_packages.extend([line for line in stripped_lines if re.match(r'^git\+.*', line)])
+        pypi_packages = [line for line in stripped_lines if line not in github_packages and "==" in line]
+
+    return {
+        "pypi": list(set(pypi_packages)),
+        "github": list(set(github_packages)),
+    }
+
+
+@health_metadata(
+    [module_dict_key],
+    {
+        "count": "count of total dependencies",
+        "pypi.count": "count of PyPI packages",
+        "pypi.list": "list of PyPI packages with required versions",
+        "github.count": "count of GitHub packages",
+        "github.list": "list of GitHub packages",
+    },
+)
+def check_dependencies(dependencies, all_results):
+    """
+    Test to find the dependencies of the repo
+    """
+    all_results[module_dict_key] = {
+        "count": len(dependencies["pypi"]) + len(dependencies["github"]),
+        "pypi": {
+            "count": len(dependencies["pypi"]),
+            "list": dependencies["pypi"],
+        },
+        "github": {
+            "count": len(dependencies["github"]),
+            "list": dependencies["github"],
+        },
+    }

--- a/repo_health/check_existence.py
+++ b/repo_health/check_existence.py
@@ -8,7 +8,7 @@ from repo_health import get_file_content
 
 
 module_dict_key = "exists"
-output_keys = {
+req_files = {
     "openedx.yaml": "openedx.yaml contains repository metadata as outlined in OEP-2",
     "Makefile": "Make targets",
     "tox.ini": "Tox configuration",
@@ -23,7 +23,11 @@ output_keys = {
     ".pii_annotations.yml": "PII annotations as outline in OEP-0030",
     ".gitignore": "git ignore configuration",
     "package.json": "packages managed by npm",
-    }
+}
+
+req_dirs = {
+    "requirements": "separate folder for requirement files",
+}
 
 
 def file_exists(repo_path, file_name):
@@ -31,15 +35,34 @@ def file_exists(repo_path, file_name):
     return bool(get_file_content(full_path))
 
 
+def dir_exists(repo_path, dir_name):
+    full_path = os.path.join(repo_path, dir_name)
+    return os.path.isdir(full_path)
+
+
 @health_metadata(
     [module_dict_key],
-    output_keys
+    req_files
 )
 def check_file_existence(repo_path, all_results):
     """
     Checks repository contains file which is not empty at root level
     """
-    for file_name, _ in output_keys.items():
+    for file_name, _ in req_files.items():
         all_results[module_dict_key][file_name] = file_exists(
             repo_path, file_name
+        )
+
+
+@health_metadata(
+    [module_dict_key],
+    req_dirs
+)
+def check_dir_existence(repo_path, all_results):
+    """
+    Checks whether repository contains required folders at root level
+    """
+    for dir_name, _ in req_dirs.items():
+        all_results[module_dict_key][dir_name] = dir_exists(
+            repo_path, dir_name
         )

--- a/repo_health/check_requirements.py
+++ b/repo_health/check_requirements.py
@@ -29,10 +29,10 @@ def fixture_req_lines(repo_path):
 @health_metadata(
     [module_dict_key],
     {
-        ("django"): "repo requires django",
-        ("pytest"): "repo requires pytest",
-        ("nose"): "repo requires nose",
-        ("boto"): "repo requires boto",
+        "django": "repo requires django",
+        "pytest": "repo requires pytest",
+        "nose": "repo requires nose",
+        "boto": "repo requires boto",
     },
 )
 def check_requires(req_lines, all_results):


### PR DESCRIPTION
**Issue:** [BOM-1977](https://openedx.atlassian.net/browse/BOM-1977)

### Description
- Check if the `requirements` folder exists.
- Extracting all the package dependencies from the `requirements` folder. 
- Splitting the `PYPI` and `GitHub` dependencies.