### PR TITLE
Unpinned importlib-metadata constraint

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,7 @@ google-auth==1.22.1       # via google-auth-oauthlib, gspread
 gspread==3.6.0            # via -r requirements/base.in
 idna-ssl==1.1.0           # via aiohttp
 idna==2.10                # via idna-ssl, requests, yarl
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, pytest
+importlib-metadata==2.0.0  # via pluggy, pytest
 iniconfig==1.0.1          # via pytest
 multidict==4.7.6          # via aiohttp, yarl
 oauthlib==3.1.0           # via requests-oauthlib

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,6 +8,3 @@
 # link to other information that will help people in the future to remove the
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
-
-# importlib-metadata>1.7.0 is causing conflicts in running make upgrade on python36
-importlib-metadata==1.7.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,7 +14,7 @@ certifi==2020.6.20        # via -r requirements/quality.txt, -r requirements/tra
 chardet==3.0.4            # via -r requirements/quality.txt, -r requirements/travis.txt, aiohttp, requests
 click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, click-log, edx-lint, pip-tools
-codecov==2.1.9            # via -r requirements/travis.txt
+codecov==2.1.10           # via -r requirements/travis.txt
 coverage==5.3             # via -r requirements/travis.txt, codecov
 diff-cover==4.0.1         # via -r requirements/dev.in
 distlib==0.3.1            # via -r requirements/travis.txt, virtualenv
@@ -28,7 +28,7 @@ google-auth==1.22.1       # via -r requirements/quality.txt, google-auth-oauthli
 gspread==3.6.0            # via -r requirements/quality.txt
 idna-ssl==1.1.0           # via -r requirements/quality.txt, aiohttp
 idna==2.10                # via -r requirements/quality.txt, -r requirements/travis.txt, idna-ssl, requests, yarl
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
+importlib-metadata==2.0.0  # via -r requirements/quality.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via -r requirements/travis.txt, virtualenv
 inflect==4.1.0            # via jinja2-pluralize
 iniconfig==1.0.1          # via -r requirements/quality.txt, pytest
@@ -66,7 +66,7 @@ smmap==3.0.4              # via -r requirements/quality.txt, gitdb
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 toml==0.10.1              # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
 tox-battery==0.6.1        # via -r requirements/dev.in
-tox==3.20.0               # via -r requirements/travis.txt, tox-battery
+tox==3.20.1               # via -r requirements/travis.txt, tox-battery
 typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
 typing-extensions==3.7.4.3  # via -r requirements/quality.txt, aiohttp, yarl
 urllib3==1.25.10          # via -r requirements/quality.txt, -r requirements/travis.txt, requests

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -25,7 +25,7 @@ gspread==3.6.0            # via -r requirements/test.txt
 idna-ssl==1.1.0           # via -r requirements/test.txt, aiohttp
 idna==2.10                # via -r requirements/test.txt, idna-ssl, requests, yarl
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, pluggy, pytest, stevedore
+importlib-metadata==2.0.0  # via -r requirements/test.txt, pluggy, pytest, stevedore
 iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 jinja2==2.11.2            # via sphinx
 markupsafe==1.1.1         # via jinja2
@@ -44,7 +44,7 @@ pytest-repo-health==2.0.1  # via -r requirements/test.txt
 pytest==6.1.1             # via -r requirements/test.txt, pytest-aiohttp, pytest-repo-health
 pytz==2020.1              # via babel
 pyyaml==5.3.1             # via -r requirements/test.txt, pytest-repo-health
-readme-renderer==26.0     # via -r requirements/doc.in
+readme-renderer==27.0     # via -r requirements/doc.in
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, google-auth-oauthlib
 requests==2.24.0          # via -r requirements/test.txt, gspread, requests-oauthlib, sphinx
 restructuredtext-lint==1.3.1  # via doc8

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -22,7 +22,7 @@ google-auth==1.22.1       # via -r requirements/test.txt, google-auth-oauthlib, 
 gspread==3.6.0            # via -r requirements/test.txt
 idna-ssl==1.1.0           # via -r requirements/test.txt, aiohttp
 idna==2.10                # via -r requirements/test.txt, idna-ssl, requests, yarl
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/test.txt, pluggy, pytest
+importlib-metadata==2.0.0  # via -r requirements/test.txt, pluggy, pytest
 iniconfig==1.0.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/quality.in, pylint
 lazy-object-proxy==1.4.3  # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,7 +18,7 @@ google-auth==1.22.1       # via -r requirements/base.txt, google-auth-oauthlib, 
 gspread==3.6.0            # via -r requirements/base.txt
 idna-ssl==1.1.0           # via -r requirements/base.txt, aiohttp
 idna==2.10                # via -r requirements/base.txt, idna-ssl, requests, yarl
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, -r requirements/base.txt, pluggy, pytest
+importlib-metadata==2.0.0  # via -r requirements/base.txt, pluggy, pytest
 iniconfig==1.0.1          # via -r requirements/base.txt, pytest
 multidict==4.7.6          # via -r requirements/base.txt, aiohttp, yarl
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -7,12 +7,12 @@
 appdirs==1.4.4            # via virtualenv
 certifi==2020.6.20        # via requests
 chardet==3.0.4            # via requests
-codecov==2.1.9            # via -r requirements/travis.in
+codecov==2.1.10           # via -r requirements/travis.in
 coverage==5.3             # via codecov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==1.7.0  # via -c requirements/constraints.txt, pluggy, tox, virtualenv
+importlib-metadata==2.0.0  # via pluggy, tox, virtualenv
 importlib-resources==3.0.0  # via virtualenv
 packaging==20.4           # via tox
 pluggy==0.13.1            # via tox
@@ -21,7 +21,7 @@ pyparsing==2.4.7          # via packaging
 requests==2.24.0          # via codecov
 six==1.15.0               # via packaging, tox, virtualenv
 toml==0.10.1              # via tox
-tox==3.20.0               # via -r requirements/travis.in
+tox==3.20.1               # via -r requirements/travis.in
 urllib3==1.25.10          # via requests
 virtualenv==20.0.33       # via tox
 zipp==3.3.0               # via importlib-metadata, importlib-resources


### PR DESCRIPTION
- `importlib-metadata<2.0.0` was causing conflicts in running `make upgrade` with `python3.6`.
- Unpinned `importlib-metadata` constraint after fixing the issue in https://github.com/pypa/virtualenv/pull/1953 and https://github.com/tox-dev/tox/pull/1682.