### PR TITLE
ARCHBOM-1475: updating pytest-repo-health to new version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,7 +29,7 @@ pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
 pyparsing==2.4.7          # via packaging
 pytest-aiohttp==0.3.0     # via pytest-repo-health
-pytest-repo-health==2.0.3  # via -r requirements/base.in
+pytest-repo-health==2.0.4  # via -r requirements/base.in
 pytest==6.1.2             # via pytest-aiohttp, pytest-repo-health
 pyyaml==5.3.1             # via -r requirements/base.in, pytest-repo-health
 requests-oauthlib==1.3.0  # via google-auth-oauthlib

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -29,7 +29,7 @@ pyasn1-modules==0.2.8     # via google-auth
 pyasn1==0.4.8             # via pyasn1-modules, rsa
 pyparsing==2.4.7          # via packaging
 pytest-aiohttp==0.3.0     # via pytest-repo-health
-pytest-repo-health==2.0.4  # via -r requirements/base.in
+pytest-repo-health==2.1.0  # via -r requirements/base.in
 pytest==6.1.2             # via pytest-aiohttp, pytest-repo-health
 pyyaml==5.3.1             # via -r requirements/base.in, pytest-repo-health
 requests-oauthlib==1.3.0  # via google-auth-oauthlib

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -55,7 +55,7 @@ pylint-plugin-utils==0.6  # via -r requirements/quality.txt, pylint-celery, pyli
 pylint==2.4.4             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/quality.txt, -r requirements/travis.txt, packaging
 pytest-aiohttp==0.3.0     # via -r requirements/quality.txt, pytest-repo-health
-pytest-repo-health==2.0.3  # via -r requirements/quality.txt
+pytest-repo-health==2.0.4  # via -r requirements/quality.txt
 pytest==6.1.2             # via -r requirements/quality.txt, pytest-aiohttp, pytest-repo-health
 pyyaml==5.3.1             # via -r requirements/quality.txt, pytest-repo-health
 requests-oauthlib==1.3.0  # via -r requirements/quality.txt, google-auth-oauthlib

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -55,7 +55,7 @@ pylint-plugin-utils==0.6  # via -r requirements/quality.txt, pylint-celery, pyli
 pylint==2.4.4             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/quality.txt, -r requirements/travis.txt, packaging
 pytest-aiohttp==0.3.0     # via -r requirements/quality.txt, pytest-repo-health
-pytest-repo-health==2.0.4  # via -r requirements/quality.txt
+pytest-repo-health==2.1.0  # via -r requirements/quality.txt
 pytest==6.1.2             # via -r requirements/quality.txt, pytest-aiohttp, pytest-repo-health
 pyyaml==5.3.1             # via -r requirements/quality.txt, pytest-repo-health
 requests-oauthlib==1.3.0  # via -r requirements/quality.txt, google-auth-oauthlib

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -40,7 +40,7 @@ pyasn1==0.4.8             # via -r requirements/test.txt, pyasn1-modules, rsa
 pygments==2.7.2           # via doc8, readme-renderer, sphinx
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-aiohttp==0.3.0     # via -r requirements/test.txt, pytest-repo-health
-pytest-repo-health==2.0.4  # via -r requirements/test.txt
+pytest-repo-health==2.1.0  # via -r requirements/test.txt
 pytest==6.1.2             # via -r requirements/test.txt, pytest-aiohttp, pytest-repo-health
 pytz==2020.1              # via babel
 pyyaml==5.3.1             # via -r requirements/test.txt, pytest-repo-health

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -40,7 +40,7 @@ pyasn1==0.4.8             # via -r requirements/test.txt, pyasn1-modules, rsa
 pygments==2.7.2           # via doc8, readme-renderer, sphinx
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-aiohttp==0.3.0     # via -r requirements/test.txt, pytest-repo-health
-pytest-repo-health==2.0.3  # via -r requirements/test.txt
+pytest-repo-health==2.0.4  # via -r requirements/test.txt
 pytest==6.1.2             # via -r requirements/test.txt, pytest-aiohttp, pytest-repo-health
 pytz==2020.1              # via babel
 pyyaml==5.3.1             # via -r requirements/test.txt, pytest-repo-health

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -42,7 +42,7 @@ pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-aiohttp==0.3.0     # via -r requirements/test.txt, pytest-repo-health
-pytest-repo-health==2.0.4  # via -r requirements/test.txt
+pytest-repo-health==2.1.0  # via -r requirements/test.txt
 pytest==6.1.2             # via -r requirements/test.txt, pytest-aiohttp, pytest-repo-health
 pyyaml==5.3.1             # via -r requirements/test.txt, pytest-repo-health
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, google-auth-oauthlib

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -42,7 +42,7 @@ pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
 pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-aiohttp==0.3.0     # via -r requirements/test.txt, pytest-repo-health
-pytest-repo-health==2.0.3  # via -r requirements/test.txt
+pytest-repo-health==2.0.4  # via -r requirements/test.txt
 pytest==6.1.2             # via -r requirements/test.txt, pytest-aiohttp, pytest-repo-health
 pyyaml==5.3.1             # via -r requirements/test.txt, pytest-repo-health
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, google-auth-oauthlib

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -29,7 +29,7 @@ pyasn1-modules==0.2.8     # via -r requirements/base.txt, google-auth
 pyasn1==0.4.8             # via -r requirements/base.txt, pyasn1-modules, rsa
 pyparsing==2.4.7          # via -r requirements/base.txt, packaging
 pytest-aiohttp==0.3.0     # via -r requirements/base.txt, pytest-repo-health
-pytest-repo-health==2.0.4  # via -r requirements/base.txt
+pytest-repo-health==2.1.0  # via -r requirements/base.txt
 pytest==6.1.2             # via -r requirements/base.txt, pytest-aiohttp, pytest-repo-health
 pyyaml==5.3.1             # via -r requirements/base.txt, pytest-repo-health
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, google-auth-oauthlib

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -29,7 +29,7 @@ pyasn1-modules==0.2.8     # via -r requirements/base.txt, google-auth
 pyasn1==0.4.8             # via -r requirements/base.txt, pyasn1-modules, rsa
 pyparsing==2.4.7          # via -r requirements/base.txt, packaging
 pytest-aiohttp==0.3.0     # via -r requirements/base.txt, pytest-repo-health
-pytest-repo-health==2.0.3  # via -r requirements/base.txt
+pytest-repo-health==2.0.4  # via -r requirements/base.txt
 pytest==6.1.2             # via -r requirements/base.txt, pytest-aiohttp, pytest-repo-health
 pyyaml==5.3.1             # via -r requirements/base.txt, pytest-repo-health
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, google-auth-oauthlib


### PR DESCRIPTION
version still needs to be merged: https://github.com/edx/pytest-repo-health/pull/58