### PR TITLE
Adding logging for travis.org api status checking.

### DIFF
--- a/repo_health/check_travis_integration.py
+++ b/repo_health/check_travis_integration.py
@@ -2,9 +2,12 @@
 Checks repository is on travis.org or .com
 """
 import json
+import logging
 
 import requests
 from pytest_repo_health import add_key_to_metadata
+
+logger = logging.getLogger(__name__)
 
 module_dict_key = "travis_ci"
 
@@ -15,10 +18,6 @@ def check_travis_integration(all_results, git_origin_url):
     Checks repository integrated with travis-ci.org or travis-ci.com
     """
 
-    # by default assume its not on .com
-    all_results[module_dict_key]['active_on_com'] = False
-    all_results[module_dict_key]['active_on_org'] = True
-
     link = git_origin_url.replace('git@github.com:edx/', '').replace('.git', '')  # picking repo name
     resp = requests.get(
         url='https://api.travis-ci.org/repo/edx%2F{link}'.format(link=link),
@@ -28,3 +27,7 @@ def check_travis_integration(all_results, git_origin_url):
     if resp.status_code == 200 and json.loads(resp.content)['migration_status'] == 'migrated':
             all_results[module_dict_key]['active_on_com'] = True
             all_results[module_dict_key]['active_on_org'] = False
+    else:
+        all_results[module_dict_key]['active_on_com'] = False
+        all_results[module_dict_key]['active_on_org'] = True
+        logger.warning(resp.status_code)


### PR DESCRIPTION
travis.org api is not giving correct result. It might be due to the rate/limit api. 
Adding some logging.