### PR TITLE
updated the travis CI migration check to use regex for repo extraction

### DIFF
--- a/repo_health/check_travis_integration.py
+++ b/repo_health/check_travis_integration.py
@@ -23,7 +23,6 @@ def check_travis_integration(all_results, git_origin_url):
 
     match = re.search(URL_PATTERN, git_origin_url)
     repo_name = match.group("repo_name")
-    
     resp = requests.get(
         url='https://api.travis-ci.org/repo/edx%2F{repo_name}'.format(repo_name=repo_name),
         headers={'Travis-API-Version': '3'}

--- a/repo_health/check_travis_integration.py
+++ b/repo_health/check_travis_integration.py
@@ -3,6 +3,7 @@ Checks repository is on travis.org or .com
 """
 import json
 import logging
+import re
 
 import requests
 from pytest_repo_health import add_key_to_metadata
@@ -24,7 +25,7 @@ def check_travis_integration(all_results, git_origin_url):
     repo_name = match.group("repo_name")
     
     resp = requests.get(
-        url='https://api.travis-ci.org/repo/edx%2F{repo_name}'.format(link=link),
+        url='https://api.travis-ci.org/repo/edx%2F{repo_name}'.format(repo_name=repo_name),
         headers={'Travis-API-Version': '3'}
     )
 

--- a/repo_health/check_travis_integration.py
+++ b/repo_health/check_travis_integration.py
@@ -11,6 +11,8 @@ logger = logging.getLogger(__name__)
 
 module_dict_key = "travis_ci"
 
+URL_PATTERN = r"github.com[/:](?P<org_name>[^/]+)/(?P<repo_name>[^/]+).git"
+
 
 @add_key_to_metadata(module_dict_key)
 def check_travis_integration(all_results, git_origin_url):
@@ -18,9 +20,11 @@ def check_travis_integration(all_results, git_origin_url):
     Checks repository integrated with travis-ci.org or travis-ci.com
     """
 
-    link = git_origin_url.replace('git@github.com:edx/', '').replace('.git', '')  # picking repo name
+    match = re.search(URL_PATTERN, git_origin_url)
+    repo_name = match.group("repo_name")
+    
     resp = requests.get(
-        url='https://api.travis-ci.org/repo/edx%2F{link}'.format(link=link),
+        url='https://api.travis-ci.org/repo/edx%2F{repo_name}'.format(link=link),
         headers={'Travis-API-Version': '3'}
     )
 


### PR DESCRIPTION
Added regex for url extraction. On jenkins its using https but locally it was using ssh link.