### PR TITLE
updated the fixture to handle all possible cases of travis integration

### DIFF
--- a/repo_health/check_travis_integration.py
+++ b/repo_health/check_travis_integration.py
@@ -5,6 +5,7 @@ import json
 import logging
 import re
 
+import pytest
 import requests
 from pytest_repo_health import add_key_to_metadata
 
@@ -12,7 +13,64 @@ logger = logging.getLogger(__name__)
 
 module_dict_key = "travis_ci"
 
+TRAVIS_API_URL = "https://api.travis-ci.com/repo/edx%2F"
+
 URL_PATTERN = r"github.com[/:](?P<org_name>[^/]+)/(?P<repo_name>[^/]+).git"
+
+
+def log_travis_api_failure(response):
+    logger.error(f"An error occurred while fetching integration information from Travis. Details: {response.content}")
+    pytest.skip("Skipped due to an error with Travis API")
+
+
+def get_travis_api_response(repo_name):
+    return requests.get(url=f'{TRAVIS_API_URL}{repo_name}',
+                        headers={'Travis-API-Version': '3', "User-Agent": "API Explorer"})
+
+
+class TravisIntegrationHandler:
+    """
+    sets up the operations and required travis CI integration information on instance
+    """
+
+    def __init__(self, repo_name):
+        self.active_on_com = False
+        self.active_on_org = False
+        self.active = False
+        self.repo_name = repo_name
+        self.travis_api_data = None
+        self._set_travis_integration_data()
+
+    def _set_travis_integration_data(self):
+        self.travis_api_response = get_travis_api_response(self.repo_name)
+
+    def _set_active_on_com(self):
+        self.active_on_com = (self.travis_api_data['migration_status'] is None or
+                              self.travis_api_data['migration_status'] == 'migrated') and \
+                             (self.travis_api_data['active_on_org'] is False)
+
+    def _set_active_on_org(self):
+        self.active_on_org = self.travis_api_data['migration_status'] is None and \
+                             self.travis_api_data['active_on_org'] is True
+
+    def _set_active(self):
+        self.active = True
+
+    def handle(self):
+        """
+        initiates the process to fetch travis CI integration information
+        """
+
+        if self.travis_api_response.status_code == 404:
+            return
+        elif self.travis_api_response.status_code != 404 and not self.travis_api_response.ok:
+            log_travis_api_failure(self.travis_api_response)
+            return
+
+        self.travis_api_data = json.loads(self.travis_api_response.content)
+        self._set_active()
+        self._set_active_on_com()
+        self._set_active_on_org()
 
 
 @add_key_to_metadata(module_dict_key)
@@ -20,18 +78,11 @@ def check_travis_integration(all_results, git_origin_url):
     """
     Checks repository integrated with travis-ci.org or travis-ci.com
     """
-
     match = re.search(URL_PATTERN, git_origin_url)
     repo_name = match.group("repo_name")
-    resp = requests.get(
-        url='https://api.travis-ci.org/repo/edx%2F{repo_name}'.format(repo_name=repo_name),
-        headers={'Travis-API-Version': '3'}
-    )
+    travis_integration_handler = TravisIntegrationHandler(repo_name)
+    travis_integration_handler.handle()
 
-    if resp.status_code == 200 and json.loads(resp.content)['migration_status'] == 'migrated':
-            all_results[module_dict_key]['active_on_com'] = True
-            all_results[module_dict_key]['active_on_org'] = False
-    else:
-        all_results[module_dict_key]['active_on_com'] = False
-        all_results[module_dict_key]['active_on_org'] = True
-        logger.warning(resp.status_code)
+    all_results[module_dict_key]['active_on_com'] = travis_integration_handler.active_on_com
+    all_results[module_dict_key]['active_on_org'] = travis_integration_handler.active_on_org
+    all_results[module_dict_key]['active'] = travis_integration_handler.active

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -59,9 +59,10 @@ pytest-repo-health==2.1.0  # via -r requirements/quality.txt
 pytest==6.1.2             # via -r requirements/quality.txt, pytest-aiohttp, pytest-repo-health
 pyyaml==5.3.1             # via -r requirements/quality.txt, pytest-repo-health
 requests-oauthlib==1.3.0  # via -r requirements/quality.txt, google-auth-oauthlib
-requests==2.25.0          # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, gspread, requests-oauthlib
+requests==2.25.0          # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, gspread, requests-oauthlib, responses
+responses==0.12.1         # via -r requirements/quality.txt
 rsa==4.6                  # via -r requirements/quality.txt, google-auth
-six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, edx-lint, google-auth, packaging, pip-tools, tox, virtualenv
+six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, edx-lint, google-auth, packaging, pip-tools, responses, tox, virtualenv
 smmap==3.0.4              # via -r requirements/quality.txt, gitdb
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 toml==0.10.2              # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
@@ -69,7 +70,7 @@ tox-battery==0.6.1        # via -r requirements/dev.in
 tox==3.20.1               # via -r requirements/travis.txt, tox-battery
 typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
 typing-extensions==3.7.4.3  # via -r requirements/quality.txt, aiohttp, yarl
-urllib3==1.26.2           # via -r requirements/quality.txt, -r requirements/travis.txt, requests
+urllib3==1.26.2           # via -r requirements/quality.txt, -r requirements/travis.txt, requests, responses
 virtualenv==20.1.0        # via -r requirements/travis.txt, tox
 wrapt==1.11.2             # via -r requirements/quality.txt, astroid
 yarl==1.6.2               # via -r requirements/quality.txt, aiohttp

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -46,10 +46,11 @@ pytz==2020.4              # via babel
 pyyaml==5.3.1             # via -r requirements/test.txt, pytest-repo-health
 readme-renderer==28.0     # via -r requirements/doc.in
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, google-auth-oauthlib
-requests==2.25.0          # via -r requirements/test.txt, gspread, requests-oauthlib, sphinx
+requests==2.25.0          # via -r requirements/test.txt, gspread, requests-oauthlib, responses, sphinx
+responses==0.12.1         # via -r requirements/test.txt
 restructuredtext-lint==1.3.1  # via doc8
 rsa==4.6                  # via -r requirements/test.txt, google-auth
-six==1.15.0               # via -r requirements/test.txt, bleach, doc8, edx-sphinx-theme, google-auth, packaging, readme-renderer
+six==1.15.0               # via -r requirements/test.txt, bleach, doc8, edx-sphinx-theme, google-auth, packaging, readme-renderer, responses
 smmap==3.0.4              # via -r requirements/test.txt, gitdb
 snowballstemmer==2.0.0    # via sphinx
 sphinx==3.3.1             # via -r requirements/doc.in, edx-sphinx-theme
@@ -62,7 +63,7 @@ sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 stevedore==3.2.2          # via doc8
 toml==0.10.2              # via -r requirements/test.txt, pytest
 typing-extensions==3.7.4.3  # via -r requirements/test.txt, aiohttp, yarl
-urllib3==1.26.2           # via -r requirements/test.txt, requests
+urllib3==1.26.2           # via -r requirements/test.txt, requests, responses
 webencodings==0.5.1       # via bleach
 yarl==1.6.2               # via -r requirements/test.txt, aiohttp
 zipp==3.4.0               # via -r requirements/test.txt, importlib-metadata

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -46,15 +46,16 @@ pytest-repo-health==2.1.0  # via -r requirements/test.txt
 pytest==6.1.2             # via -r requirements/test.txt, pytest-aiohttp, pytest-repo-health
 pyyaml==5.3.1             # via -r requirements/test.txt, pytest-repo-health
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, google-auth-oauthlib
-requests==2.25.0          # via -r requirements/test.txt, gspread, requests-oauthlib
+requests==2.25.0          # via -r requirements/test.txt, gspread, requests-oauthlib, responses
+responses==0.12.1         # via -r requirements/test.txt
 rsa==4.6                  # via -r requirements/test.txt, google-auth
-six==1.15.0               # via -r requirements/test.txt, astroid, edx-lint, google-auth, packaging
+six==1.15.0               # via -r requirements/test.txt, astroid, edx-lint, google-auth, packaging, responses
 smmap==3.0.4              # via -r requirements/test.txt, gitdb
 snowballstemmer==2.0.0    # via pydocstyle
 toml==0.10.2              # via -r requirements/test.txt, pytest
 typed-ast==1.4.1          # via astroid
 typing-extensions==3.7.4.3  # via -r requirements/test.txt, aiohttp, yarl
-urllib3==1.26.2           # via -r requirements/test.txt, requests
+urllib3==1.26.2           # via -r requirements/test.txt, requests, responses
 wrapt==1.11.2             # via astroid
 yarl==1.6.2               # via -r requirements/test.txt, aiohttp
 zipp==3.4.0               # via -r requirements/test.txt, importlib-metadata

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -2,3 +2,4 @@
 -c constraints.txt
 
 -r base.txt               # Core dependencies for this package
+responses

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -33,13 +33,14 @@ pytest-repo-health==2.1.0  # via -r requirements/base.txt
 pytest==6.1.2             # via -r requirements/base.txt, pytest-aiohttp, pytest-repo-health
 pyyaml==5.3.1             # via -r requirements/base.txt, pytest-repo-health
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, google-auth-oauthlib
-requests==2.25.0          # via -r requirements/base.txt, gspread, requests-oauthlib
+requests==2.25.0          # via -r requirements/base.txt, gspread, requests-oauthlib, responses
+responses==0.12.1         # via -r requirements/test.in
 rsa==4.6                  # via -r requirements/base.txt, google-auth
-six==1.15.0               # via -r requirements/base.txt, google-auth, packaging
+six==1.15.0               # via -r requirements/base.txt, google-auth, packaging, responses
 smmap==3.0.4              # via -r requirements/base.txt, gitdb
 toml==0.10.2              # via -r requirements/base.txt, pytest
 typing-extensions==3.7.4.3  # via -r requirements/base.txt, aiohttp, yarl
-urllib3==1.26.2           # via -r requirements/base.txt, requests
+urllib3==1.26.2           # via -r requirements/base.txt, requests, responses
 yarl==1.6.2               # via -r requirements/base.txt, aiohttp
 zipp==3.4.0               # via -r requirements/base.txt, importlib-metadata
 

--- a/tests/test_travis_integration.py
+++ b/tests/test_travis_integration.py
@@ -1,0 +1,59 @@
+from unittest.mock import patch
+
+import requests
+import responses
+
+from repo_health.check_travis_integration import TRAVIS_API_URL, TravisIntegrationHandler
+
+
+@responses.activate
+def mock_non_existent_repo_response():
+    url = "{api_url}{repo_name}".format(api_url=TRAVIS_API_URL, repo_name="edx-platform")
+    responses.add(responses.GET, url, json={"@type": "error", "error_type": "not_found",
+                                            "error_message": "repository not found (or insufficient access)",
+                                            "resource_type": "repository"}, status=404)
+    return requests.get(url)
+
+
+@responses.activate
+def mock_on_com_repo_response():
+    url = "{api_url}{repo_name}".format(api_url=TRAVIS_API_URL, repo_name="edx-cookiecutters")
+    responses.add(responses.GET, url, json={"active_on_org": False, "migration_status": None}, status=200)
+    return requests.get(url)
+
+
+@responses.activate
+def mock_migrated_repo_response():
+    url = "{api_url}{repo_name}".format(api_url=TRAVIS_API_URL, repo_name="ecommerce")
+    responses.add(responses.GET, url, json={"active_on_org": False, "migration_status": "migrated"}, status=200)
+    return requests.get(url)
+
+
+@patch('repo_health.check_travis_integration.get_travis_api_response', return_value=mock_non_existent_repo_response())
+def test_integration_non_existent_repo(mock_non_existent_repo_response):
+    travis_integration_handler = TravisIntegrationHandler("edx-platform")
+    travis_integration_handler.handle()
+
+    assert travis_integration_handler.active is False
+    assert travis_integration_handler.active_on_org is False
+    assert travis_integration_handler.active_on_com is False
+
+
+@patch('repo_health.check_travis_integration.get_travis_api_response', return_value=mock_on_com_repo_response())
+def test_integration_active_on_com_repo(mock_on_com_repo_response):
+    travis_integration_handler = TravisIntegrationHandler("edx-cookiecutters")
+    travis_integration_handler.handle()
+
+    assert travis_integration_handler.active is True
+    assert travis_integration_handler.active_on_org is False
+    assert travis_integration_handler.active_on_com is True
+
+
+@patch('repo_health.check_travis_integration.get_travis_api_response', return_value=mock_migrated_repo_response())
+def test_integration_migrated_repo(mock_migrated_repo_response):
+    travis_integration_handler = TravisIntegrationHandler("ecommerce")
+    travis_integration_handler.handle()
+
+    assert travis_integration_handler.active is True
+    assert travis_integration_handler.active_on_org is False
+    assert travis_integration_handler.active_on_com is True

--- a/tox.ini
+++ b/tox.ini
@@ -30,11 +30,11 @@ ignore = D101,D200,D203,D212,D215,D404,D405,D406,D407,D408,D409,D410,D411,D412,D
 match-dir = (?!migrations)
 
 
-#[testenv]
-#deps =
-#    -r{toxinidir}/requirements/test.txt
-#commands =
-#    pytest {posargs}
+[testenv]
+deps =
+    -r{toxinidir}/requirements/test.txt
+commands =
+    pytest {posargs}
 
 [testenv:docs]
 setenv =


### PR DESCRIPTION
updated the script to use **travis-ci.com** API instead of **travis-ci.org** and changes made to handle all possible cases.
the updated script has been tested with the following scenarios:
- a repo that was migrated over from **travis-ci.org** to **travis-ci.com** e.g `ecommerce`
- a repo that never used travis CI e.g `edx-platform`
- a repo that never used travis-ci.org and started out with travis-ci.com instead (no migration history) e.g `edx-cookiecutters`