### PR TITLE
BOM-2091: Cover Python version float edge case

### DIFF
--- a/repo_health/check_travis_yml.py
+++ b/repo_health/check_travis_yml.py
@@ -53,7 +53,8 @@ def fixture_python_version(parsed_data_travis):
     """
     python_versions = set()
     if "python" in parsed_data_travis.keys():
-        python_versions = set(parsed_data_travis["python"])
+        py_versions = parsed_data_travis["python"]
+        python_versions = set([py_versions] if isinstance(py_versions, float) else py_versions)
 
     if "matrix" in parsed_data_travis.keys():
         workers = None


### PR DESCRIPTION
Following error came when we added forks and archived repos in `org-repo-health-report` job, so made a fix.
```
10:47:40     @pytest.fixture(name="python_versions_in_travis")
10:47:40     def fixture_python_version(parsed_data_travis):
10:47:40         """
10:47:40         The list of python versions in travis tests
10:47:40         """
10:47:40         python_versions = set()
10:47:40         if "python" in parsed_data_travis.keys():
10:47:40 >           python_versions = set(parsed_data_travis["python"])
10:47:40 E           TypeError: 'float' object is not iterable
```