### PR TITLE
Pinned Importlib-metadata<3.0 because of tox and virtualenv

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,11 +18,11 @@ google-auth==1.23.0       # via google-auth-oauthlib, gspread
 gspread==3.6.0            # via -r requirements/base.in
 idna-ssl==1.1.0           # via aiohttp
 idna==2.10                # via idna-ssl, requests, yarl
-importlib-metadata==2.0.0  # via pluggy, pytest
+importlib-metadata==2.1.0  # via -c requirements/constraints.txt, pluggy, pytest
 iniconfig==1.1.1          # via pytest
 multidict==5.0.2          # via aiohttp, yarl
 oauthlib==3.1.0           # via requests-oauthlib
-packaging==20.4           # via pytest
+packaging==20.7           # via pytest
 pluggy==0.13.1            # via pytest
 py==1.9.0                 # via pytest
 pyasn1-modules==0.2.8     # via google-auth
@@ -35,7 +35,7 @@ pyyaml==5.3.1             # via -r requirements/base.in, pytest-repo-health
 requests-oauthlib==1.3.0  # via google-auth-oauthlib
 requests==2.25.0          # via gspread, requests-oauthlib
 rsa==4.6                  # via google-auth
-six==1.15.0               # via google-auth, packaging
+six==1.15.0               # via google-auth
 smmap==3.0.4              # via gitdb
 toml==0.10.2              # via pytest
 typing-extensions==3.7.4.3  # via aiohttp, yarl

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,3 +8,8 @@
 # link to other information that will help people in the future to remove the
 # pin when possible.  Writing an issue against the offending project and
 # linking to it here is good.
+
+# Tox and virtualenv require importlib-metadata<3.0 to support python3.5
+# so pinning until both packages drop support for python3.5 &
+# update their required importlib-metadata version constraint
+importlib-metadata<3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -28,7 +28,7 @@ google-auth==1.23.0       # via -r requirements/quality.txt, google-auth-oauthli
 gspread==3.6.0            # via -r requirements/quality.txt
 idna-ssl==1.1.0           # via -r requirements/quality.txt, aiohttp
 idna==2.10                # via -r requirements/quality.txt, -r requirements/travis.txt, idna-ssl, requests, yarl
-importlib-metadata==2.0.0  # via -r requirements/quality.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
+importlib-metadata==2.1.0  # via -c requirements/constraints.txt, -r requirements/quality.txt, -r requirements/travis.txt, pluggy, pytest, tox, virtualenv
 importlib-resources==3.3.0  # via -r requirements/travis.txt, virtualenv
 inflect==5.0.2            # via jinja2-pluralize
 iniconfig==1.1.1          # via -r requirements/quality.txt, pytest
@@ -40,8 +40,8 @@ markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, pylint
 multidict==5.0.2          # via -r requirements/quality.txt, aiohttp, yarl
 oauthlib==3.1.0           # via -r requirements/quality.txt, requests-oauthlib
-packaging==20.4           # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
-pip-tools==5.3.1          # via -r requirements/pip-tools.txt
+packaging==20.7           # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
+pip-tools==5.4.0          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/quality.txt, -r requirements/travis.txt, diff-cover, pytest, tox
 py==1.9.0                 # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
 pyasn1-modules==0.2.8     # via -r requirements/quality.txt, google-auth
@@ -62,7 +62,7 @@ requests-oauthlib==1.3.0  # via -r requirements/quality.txt, google-auth-oauthli
 requests==2.25.0          # via -r requirements/quality.txt, -r requirements/travis.txt, codecov, gspread, requests-oauthlib, responses
 responses==0.12.1         # via -r requirements/quality.txt
 rsa==4.6                  # via -r requirements/quality.txt, google-auth
-six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, edx-lint, google-auth, packaging, pip-tools, responses, tox, virtualenv
+six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, -r requirements/travis.txt, astroid, edx-lint, google-auth, pip-tools, responses, tox, virtualenv
 smmap==3.0.4              # via -r requirements/quality.txt, gitdb
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 toml==0.10.2              # via -r requirements/quality.txt, -r requirements/travis.txt, pytest, tox
@@ -71,7 +71,7 @@ tox==3.20.1               # via -r requirements/travis.txt, tox-battery
 typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
 typing-extensions==3.7.4.3  # via -r requirements/quality.txt, aiohttp, yarl
 urllib3==1.26.2           # via -r requirements/quality.txt, -r requirements/travis.txt, requests, responses
-virtualenv==20.1.0        # via -r requirements/travis.txt, tox
+virtualenv==20.2.1        # via -r requirements/travis.txt, tox
 wrapt==1.11.2             # via -r requirements/quality.txt, astroid
 yarl==1.6.3               # via -r requirements/quality.txt, aiohttp
 zipp==3.4.0               # via -r requirements/quality.txt, -r requirements/travis.txt, importlib-metadata, importlib-resources

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -25,13 +25,13 @@ gspread==3.6.0            # via -r requirements/test.txt
 idna-ssl==1.1.0           # via -r requirements/test.txt, aiohttp
 idna==2.10                # via -r requirements/test.txt, idna-ssl, requests, yarl
 imagesize==1.2.0          # via sphinx
-importlib-metadata==2.0.0  # via -r requirements/test.txt, pluggy, pytest, stevedore
+importlib-metadata==2.1.0  # via -c requirements/constraints.txt, -r requirements/test.txt, pluggy, pytest, stevedore
 iniconfig==1.1.1          # via -r requirements/test.txt, pytest
 jinja2==2.11.2            # via sphinx
 markupsafe==1.1.1         # via jinja2
 multidict==5.0.2          # via -r requirements/test.txt, aiohttp, yarl
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib
-packaging==20.4           # via -r requirements/test.txt, bleach, pytest, sphinx
+packaging==20.7           # via -r requirements/test.txt, bleach, pytest, sphinx
 pbr==5.5.1                # via stevedore
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 py==1.9.0                 # via -r requirements/test.txt, pytest
@@ -48,9 +48,9 @@ readme-renderer==28.0     # via -r requirements/doc.in
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, google-auth-oauthlib
 requests==2.25.0          # via -r requirements/test.txt, gspread, requests-oauthlib, responses, sphinx
 responses==0.12.1         # via -r requirements/test.txt
-restructuredtext-lint==1.3.1  # via doc8
+restructuredtext-lint==1.3.2  # via doc8
 rsa==4.6                  # via -r requirements/test.txt, google-auth
-six==1.15.0               # via -r requirements/test.txt, bleach, doc8, edx-sphinx-theme, google-auth, packaging, readme-renderer, responses
+six==1.15.0               # via -r requirements/test.txt, bleach, doc8, edx-sphinx-theme, google-auth, readme-renderer, responses
 smmap==3.0.4              # via -r requirements/test.txt, gitdb
 snowballstemmer==2.0.0    # via sphinx
 sphinx==3.3.1             # via -r requirements/doc.in, edx-sphinx-theme

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,7 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.3.1          # via -r requirements/pip-tools.in
+pip-tools==5.4.0          # via -r requirements/pip-tools.in
 six==1.15.0               # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -22,14 +22,14 @@ google-auth==1.23.0       # via -r requirements/test.txt, google-auth-oauthlib, 
 gspread==3.6.0            # via -r requirements/test.txt
 idna-ssl==1.1.0           # via -r requirements/test.txt, aiohttp
 idna==2.10                # via -r requirements/test.txt, idna-ssl, requests, yarl
-importlib-metadata==2.0.0  # via -r requirements/test.txt, pluggy, pytest
+importlib-metadata==2.1.0  # via -c requirements/constraints.txt, -r requirements/test.txt, pluggy, pytest
 iniconfig==1.1.1          # via -r requirements/test.txt, pytest
 isort==4.3.21             # via -r requirements/quality.in, pylint
 lazy-object-proxy==1.4.3  # via astroid
 mccabe==0.6.1             # via pylint
 multidict==5.0.2          # via -r requirements/test.txt, aiohttp, yarl
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib
-packaging==20.4           # via -r requirements/test.txt, pytest
+packaging==20.7           # via -r requirements/test.txt, pytest
 pluggy==0.13.1            # via -r requirements/test.txt, pytest
 py==1.9.0                 # via -r requirements/test.txt, pytest
 pyasn1-modules==0.2.8     # via -r requirements/test.txt, google-auth
@@ -49,7 +49,7 @@ requests-oauthlib==1.3.0  # via -r requirements/test.txt, google-auth-oauthlib
 requests==2.25.0          # via -r requirements/test.txt, gspread, requests-oauthlib, responses
 responses==0.12.1         # via -r requirements/test.txt
 rsa==4.6                  # via -r requirements/test.txt, google-auth
-six==1.15.0               # via -r requirements/test.txt, astroid, edx-lint, google-auth, packaging, responses
+six==1.15.0               # via -r requirements/test.txt, astroid, edx-lint, google-auth, responses
 smmap==3.0.4              # via -r requirements/test.txt, gitdb
 snowballstemmer==2.0.0    # via pydocstyle
 toml==0.10.2              # via -r requirements/test.txt, pytest

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,11 +18,11 @@ google-auth==1.23.0       # via -r requirements/base.txt, google-auth-oauthlib, 
 gspread==3.6.0            # via -r requirements/base.txt
 idna-ssl==1.1.0           # via -r requirements/base.txt, aiohttp
 idna==2.10                # via -r requirements/base.txt, idna-ssl, requests, yarl
-importlib-metadata==2.0.0  # via -r requirements/base.txt, pluggy, pytest
+importlib-metadata==2.1.0  # via -c requirements/constraints.txt, -r requirements/base.txt, pluggy, pytest
 iniconfig==1.1.1          # via -r requirements/base.txt, pytest
 multidict==5.0.2          # via -r requirements/base.txt, aiohttp, yarl
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib
-packaging==20.4           # via -r requirements/base.txt, pytest
+packaging==20.7           # via -r requirements/base.txt, pytest
 pluggy==0.13.1            # via -r requirements/base.txt, pytest
 py==1.9.0                 # via -r requirements/base.txt, pytest
 pyasn1-modules==0.2.8     # via -r requirements/base.txt, google-auth
@@ -36,7 +36,7 @@ requests-oauthlib==1.3.0  # via -r requirements/base.txt, google-auth-oauthlib
 requests==2.25.0          # via -r requirements/base.txt, gspread, requests-oauthlib, responses
 responses==0.12.1         # via -r requirements/test.in
 rsa==4.6                  # via -r requirements/base.txt, google-auth
-six==1.15.0               # via -r requirements/base.txt, google-auth, packaging, responses
+six==1.15.0               # via -r requirements/base.txt, google-auth, responses
 smmap==3.0.4              # via -r requirements/base.txt, gitdb
 toml==0.10.2              # via -r requirements/base.txt, pytest
 typing-extensions==3.7.4.3  # via -r requirements/base.txt, aiohttp, yarl

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -12,16 +12,16 @@ coverage==5.3             # via codecov
 distlib==0.3.1            # via virtualenv
 filelock==3.0.12          # via tox, virtualenv
 idna==2.10                # via requests
-importlib-metadata==2.0.0  # via pluggy, tox, virtualenv
+importlib-metadata==2.1.0  # via -c requirements/constraints.txt, pluggy, tox, virtualenv
 importlib-resources==3.3.0  # via virtualenv
-packaging==20.4           # via tox
+packaging==20.7           # via tox
 pluggy==0.13.1            # via tox
 py==1.9.0                 # via tox
 pyparsing==2.4.7          # via packaging
 requests==2.25.0          # via codecov
-six==1.15.0               # via packaging, tox, virtualenv
+six==1.15.0               # via tox, virtualenv
 toml==0.10.2              # via tox
 tox==3.20.1               # via -r requirements/travis.in
 urllib3==1.26.2           # via requests
-virtualenv==20.1.0        # via tox
+virtualenv==20.2.1        # via tox
 zipp==3.4.0               # via importlib-metadata, importlib-resources


### PR DESCRIPTION
`importlib-metadata>3.0` dropped support for `python3.5` but `Tox` and `virtualenv` require `importlib-metadata<3.0` to support `python3.5` so pinning until both packages drop support for `python3.5` & update their required `importlib-metadata` version constraint.