### PR TITLE
feat: run_checks CLI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include README.rst
 include requirements/base.in
 recursive-include repo_health *.html *.png *.gif *.js *.css *.jpg *.jpeg *.svg *.py
 recursive-include repo_health_dashboard *.html *.png *.gif *.js *.css *.jpg *.jpeg *.svg *.py
+recursive-include scripts *.py

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,28 @@ edx-repo-health is a set of checks of the health of repositories.  They are writ
 - The completed dictionary is written as a YAML file when all the checks have
   been run.
 
+Installation
+------------
+
+1. git clone this repository::
+
+   $ git clone git@github.com:edx/edx-repo-health.git
+
+2. run `make requirements` to install reqs for this repo
+3. run `pip install -e .` to install this project
+
+Usage
+-----
+
+- Follow Installation steps above
+- cd into the directory you wish to run checks on
+- Run the `run_checks` command
+
+ `run_checks` is a CLI wrapper around pytest-repo-health_. Running `run_checks` will run all checks located in edx-repo-health repo on the directory you are currently cd'd into.
+
+  As of now, there is no way to further modify plugin behavior using the CLI `run_checks`, for more custom    behavior, please see readme in pytest-repo-health_.
+
+
 Design
 ------
 

--- a/scripts/run_checks.py
+++ b/scripts/run_checks.py
@@ -12,7 +12,7 @@ def main():
     Initiates pytest in repo-health mode
     """
     checks_dir = pathlib.Path(__file__).parent.parent.absolute()
-    pytest.main(["-c", "<()", "--noconftest", "--repo-health", "--repo-health-path", str(checks_dir)])
+    pytest.main(["--noconftest", "--repo-health", "--repo-health-path", str(checks_dir)])
 
 
 if __name__ == "__main__":

--- a/scripts/run_checks.py
+++ b/scripts/run_checks.py
@@ -1,0 +1,13 @@
+import argparse
+import pytest
+import pathlib
+
+
+
+def main():
+    checks_dir = pathlib.Path(__file__).parent.parent.absolute()
+    pytest.main(["-c", "<()", "--noconftest", "--repo-health", "--repo-health-path", str(checks_dir)])
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_checks.py
+++ b/scripts/run_checks.py
@@ -1,10 +1,16 @@
+"""
+Wrapper CLI around pytest call to allow users to use checks in this repo
+without knowing much about pytest-repo-health
+"""
 import argparse
 import pytest
 import pathlib
 
 
-
 def main():
+    """
+    Initiates pytest in repo-health mode
+    """
     checks_dir = pathlib.Path(__file__).parent.parent.absolute()
     pytest.main(["-c", "<()", "--noconftest", "--repo-health", "--repo-health-path", str(checks_dir)])
 

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,8 @@ setup(
     ],
     entry_points={
         "console_scripts": [
-            "repo_health_dashboard = repo_health_dashboard.repo_health_dashboard:main"
+            "repo_health_dashboard = repo_health_dashboard.repo_health_dashboard:main",
+            "run_checks = scripts.run_checks:main",
         ]
     },
 )


### PR DESCRIPTION
Adding new script called scripts/run_checks to make it easier to run
the checks in this repository without knowing too much about the internals of
pytest-repo-health

This script mostly takes care of the defaults and does not allow you to change
any options from default

Assumption:
Those running this script will be using checks in the repository on some external
repository