### PR TITLE
fix: don't accidentally iterate string keys

### DIFF
--- a/repo_health/check_github_integration.py
+++ b/repo_health/check_github_integration.py
@@ -72,7 +72,7 @@ class GitHubIntegrationHandler:
             ]
 
 
-@add_key_to_metadata(module_dict_key)
+@add_key_to_metadata((module_dict_key,))
 def check_githuba_actions_integration(all_results, git_origin_url):
     """
     Checks repository integrated with github actions workflow

--- a/repo_health/check_travis_integration.py
+++ b/repo_health/check_travis_integration.py
@@ -75,7 +75,7 @@ class TravisIntegrationHandler:
         self._set_active_on_org()
 
 
-@add_key_to_metadata(module_dict_key)
+@add_key_to_metadata((module_dict_key,))
 def check_travis_integration(all_results, git_origin_url):
     """
     Checks repository integrated with travis-ci.org or travis-ci.com


### PR DESCRIPTION
The "checks description" tab of the results spreadsheet has
"g.i.t.h.u.b._.a.c.t.i.o.n.s" and "t.r.a.v.i.s._.c.i" because the
argument to add_key_to_metadata is iterated, and strings are iterable.

This fixes it.