### PR TITLE
fix: Be able to handle URLs that fail to connect.

### DIFF
--- a/repo_health/check_readme.py
+++ b/repo_health/check_readme.py
@@ -137,7 +137,12 @@ def check_readme_links(readme, all_results):
         seen.add(url)
         if is_example_url(url):
             continue
-        resp = requests.head(url, allow_redirects=True)
+        try:
+            resp = requests.head(url, allow_redirects=True)
+        except requests.ConnectionError as e:
+            bad[url] = str(e)
+            continue
+
         if 200 <= resp.status_code <= 300:
             good.append(url)
         else:

--- a/tests/test_check_readme.py
+++ b/tests/test_check_readme.py
@@ -1,0 +1,17 @@
+from unittest.mock import patch
+
+import requests
+import responses
+
+from repo_health.check_readme import check_readme_links, module_dict_key
+
+
+@responses.activate
+def test_bad_connection():
+    # If you attempt to fetch a url which isn't registered, responses will raise a ConnectionError:
+    bad_url = "http://google.com/"
+    test_readme = f"{bad_url} is the place to go for more info."
+    all_results = {module_dict_key: {}}
+    check_readme_links(test_readme, all_results)
+    assert "bad_links" in all_results[module_dict_key]
+    assert bad_url in all_results[module_dict_key]["bad_links"]


### PR DESCRIPTION
In some cases, we might get DNS or other network connection error when
establishing a connection.  Set those as bad URLs as well.