### PR TITLE
BOM-2457 : Create repo health check for Renovate usage

### DIFF
--- a/repo_health/check_existence.py
+++ b/repo_health/check_existence.py
@@ -1,10 +1,9 @@
 """
 Functions to check the existence of files.
 """
-import os
-
 from pytest_repo_health import health_metadata
-from repo_health import get_file_content
+
+from .utils import dir_exists, file_exists
 
 
 module_dict_key = "exists"
@@ -28,16 +27,6 @@ req_files = {
 req_dirs = {
     "requirements": "separate folder for requirement files",
 }
-
-
-def file_exists(repo_path, file_name):
-    full_path = os.path.join(repo_path, file_name)
-    return bool(get_file_content(full_path))
-
-
-def dir_exists(repo_path, dir_name):
-    full_path = os.path.join(repo_path, dir_name)
-    return os.path.isdir(full_path)
 
 
 @health_metadata(

--- a/repo_health/check_renovate.py
+++ b/repo_health/check_renovate.py
@@ -1,0 +1,76 @@
+"""
+Checks for renovate configuration
+"""
+import json
+import os
+
+from pytest_repo_health import health_metadata
+
+from . import get_file_content
+from .utils import file_exists
+
+MODULE_DICT_KEY = "renovate"
+
+LAST_PR_QUERY = """
+query searchRepos($filter: String!) {
+  search(query: $filter, type: ISSUE, last: 1) {
+    nodes {
+      ... on PullRequest {
+        createdAt
+      }
+    }
+  }
+}
+"""
+
+POSSIBLE_CONFIG_PATHS = [
+    ".github/renovate.json",
+    ".github/renovate.json5",
+    ".gitlab/renovate.json",
+    ".gitlab/renovate.json5",
+    ".renovaterc.json",
+    "renovate.json",
+    "renovate.json5",
+    ".renovaterc"
+]
+
+
+async def get_last_pull_date(github_repo):
+    """
+    Fetches the last pull request made by renovate
+    """
+    repo = github_repo.object
+    client = repo.http
+    kwargs = {
+        "filter": f"repo:edx/{repo.name} type:pr author:app/renovate"
+    }
+
+    _json = {
+        "query": LAST_PR_QUERY,
+        "variables": kwargs,
+    }
+    data = await client.request(json=_json)
+    if len(data['search']['nodes']):
+        return data['search']['nodes'][0]['createdAt'][:10]
+
+
+@health_metadata(
+    [MODULE_DICT_KEY],
+    {
+        "configured": "Flag for existence of renovate configuration",
+        "last_pr": "Date of last Pull Request made by renovate",
+    }
+)
+async def check_renovate(all_results, repo_path, github_repo):
+    """
+    Checks whether repository contains configuration for renovate and is making PR
+    """
+    config_exists = any(file_exists(repo_path, path) for path in POSSIBLE_CONFIG_PATHS)
+    if not config_exists and file_exists(repo_path, 'package.json'):
+        content = get_file_content(os.path.join(repo_path, 'package.json'))
+        config_exists = 'renovate' in json.loads(content)
+
+    all_results[MODULE_DICT_KEY] = {
+        'configured': config_exists,
+        'last_pr': await get_last_pull_date(github_repo) if config_exists else None
+    }

--- a/repo_health/utils.py
+++ b/repo_health/utils.py
@@ -3,10 +3,20 @@ Utility Functions
 """
 import functools
 import operator
+import os
 from datetime import datetime
 
-
 GITHUB_DATETIME_FMT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def file_exists(repo_path, file_name):
+    full_path = os.path.join(repo_path, file_name)
+    return os.path.isfile(full_path)
+
+
+def dir_exists(repo_path, dir_name):
+    full_path = os.path.join(repo_path, dir_name)
+    return os.path.isdir(full_path)
 
 
 def parse_build_duration_response(json_response):


### PR DESCRIPTION
Adding a health check to track which repos use [renovate](https://github.com/renovatebot/renovate) for Javascript dependency management and when did renovate made last PR if it is configured.

Relevant JIRA : https://openedx.atlassian.net/browse/BOM-2457