### PR TITLE
refactor: converting dependencies list into json.

### DIFF
--- a/repo_health/check_dependencies.py
+++ b/repo_health/check_dependencies.py
@@ -29,7 +29,6 @@ def fixture_req_packages(repo_path):
         stripped_lines = [re.sub(r' +#.*', "", line).replace('-e ', "")
                           for line in lines if line and not line.startswith("#")]
 
-
         for line in stripped_lines:
             if re.match(r'^git\+.*', line):
                 key_val = line.split('==')

--- a/repo_health/check_dependencies.py
+++ b/repo_health/check_dependencies.py
@@ -1,12 +1,14 @@
 """
  Checks which are the dependencies of the repo
 """
+import json
+import os
 import re
 from pathlib import Path
-import os
 
 import pytest
 from pytest_repo_health import health_metadata
+
 from repo_health import get_file_lines
 
 module_dict_key = "dependencies"
@@ -17,8 +19,8 @@ def fixture_req_packages(repo_path):
     """
     Fixture containing the text content of req_files
     """
-    pypi_packages = []
-    github_packages = []
+    pypi_packages = {}
+    github_packages = {}
     files = [str(file) for file in Path(os.path.join(repo_path, "requirements")).rglob('*.txt')]
     constraints_files = ("constraints.txt", "pins.txt")
     requirement_files = [file for file in files if not file.endswith(constraints_files)]
@@ -26,12 +28,21 @@ def fixture_req_packages(repo_path):
         lines = get_file_lines(file_path)
         stripped_lines = [re.sub(r' +#.*', "", line).replace('-e ', "")
                           for line in lines if line and not line.startswith("#")]
-        github_packages.extend([line for line in stripped_lines if re.match(r'^git\+.*', line)])
-        pypi_packages.extend([line for line in stripped_lines if line not in github_packages and "==" in line])
+
+
+        for line in stripped_lines:
+            if re.match(r'^git\+.*', line):
+                key_val = line.split('==')
+                github_packages.update({key_val[0]: key_val[1]})
+
+        for line in stripped_lines:
+            if line not in github_packages and "==" in line:
+                key_val = line.split('==')
+                pypi_packages.update({key_val[0]: key_val[1]})
 
     return {
-        "pypi": list(set(pypi_packages)),
-        "github": list(set(github_packages)),
+        "pypi": json.dumps(pypi_packages),
+        "github": json.dumps(github_packages),
     }
 
 

--- a/repo_health/check_github.py
+++ b/repo_health/check_github.py
@@ -105,7 +105,7 @@ async def check_build_duration(all_results, github_repo):
     data = await client.request(json=_json)
     total_duration, checks_list = parse_build_duration_response(data)
 
-    all_results[MODULE_DICT_KEY]['build_details'] = json.dump({
+    all_results[MODULE_DICT_KEY]['build_details'] = json.dumps({
         'total_duration': total_duration,
         'checks': checks_list
     })

--- a/repo_health/check_github.py
+++ b/repo_health/check_github.py
@@ -111,7 +111,6 @@ async def check_build_duration(all_results, github_repo):
     })
 
 
-
 @health_metadata(
     [MODULE_DICT_KEY],
     {

--- a/repo_health/check_github.py
+++ b/repo_health/check_github.py
@@ -105,10 +105,11 @@ async def check_build_duration(all_results, github_repo):
     data = await client.request(json=_json)
     total_duration, checks_list = parse_build_duration_response(data)
 
-    all_results[MODULE_DICT_KEY]['build_details'] = {
+    all_results[MODULE_DICT_KEY]['build_details'] = json.dump({
         'total_duration': total_duration,
         'checks': checks_list
-    }
+    })
+
 
 
 @health_metadata(


### PR DESCRIPTION
refactor: converting dependencies list into json ( part 1 )

 1: store lists as json rather than python repr’s

BOM-2478

Previous output into csv
```
['future==0.18.2', 'code-annotations==1.1.1', 'typing-extensions==3.7.4.3']
```
Latest output into csv

```
{"appdirs":   "1.4.4", "distlib": "0.3.1",   "filelock": "3.0.12", "packaging":   "20.8", "pluggy": "0.13.1"}
```


