### PR TITLE
BOM-2510: Upgrade django-debug-toolbar

### DIFF
--- a/tests/fake_repos/python_js_repo/requirements/development.txt
+++ b/tests/fake_repos/python_js_repo/requirements/development.txt
@@ -69,7 +69,7 @@ django-cookies-samesite==0.9.0  # via -r requirements/edx/testing.txt
 django-cors-headers==2.5.3  # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 django-countries==5.5     # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt, edx-enterprise
 django-crum==0.7.9        # via -r requirements/edx/testing.txt, edx-django-utils, edx-enterprise, edx-proctoring, edx-rbac, edx-toggles, super-csv
-django-debug-toolbar==3.2  # via -r requirements/edx/development.in
+django-debug-toolbar==3.2.1  # via -r requirements/edx/development.in
 django-fernet-fields==0.6  # via -r requirements/edx/testing.txt, edx-enterprise, edx-event-routing-backends, edxval
 django-filter==2.4.0      # via -r requirements/edx/testing.txt, edx-enterprise, lti-consumer-xblock
 django-ipware==3.0.2      # via -r requirements/edx/testing.txt, edx-enterprise, edx-proctoring


### PR DESCRIPTION
Currenty version of `django-debug-toolbar`being used has a known security vulnerability. Upgrading to version 3.2.1

Relevant JIRA : https://openedx.atlassian.net/browse/BOM-2510