### PR TITLE
fix: smarter URL parsing in READMEs

### DIFF
--- a/repo_health/check_readme.py
+++ b/repo_health/check_readme.py
@@ -68,7 +68,10 @@ def check_readme_contents(readme, all_results):
         all_results[module_dict_key][key] = not present
 
 
-URL_REGEX = r"https?://[\w._/?&%=@+\-\[\]]+"
+# URLs have to start with a scheme, but can have lots of stuff in them. They
+# have to end with word or slash, so that trailing punctuation won't be
+# included.
+URL_REGEX = r"https?://[\w._/?&%=@+\-\[\]]+[\w/]"
 
 # Some links in READMEs are just examples, don't bother checking these domains.
 EXAMPLE_DOMAINS = {

--- a/tests/test_check_readme.py
+++ b/tests/test_check_readme.py
@@ -1,3 +1,4 @@
+import re
 from unittest.mock import patch
 
 import requests
@@ -9,16 +10,28 @@ from repo_health.check_readme import check_readme_links, module_dict_key
 @responses.activate
 def test_one_good_one_bad():
     # If you attempt to fetch a url which isn't registered, responses will raise a ConnectionError:
-    bad_url = "http://google.com/"
-    good_url = "http://rtfd.org"
+    bad_url = "http://badurl.com/"
+    good_url = "http://goodurl.org"
 
-    responses.add(responses.HEAD, good_url, status=200)
-    test_readme = f"{bad_url} is the place to go for more info. {good_url} is better."
+    # Any url at good_url will be OK.
+    good_match = re.compile(f"{good_url}(/.*)?")
+    responses.add(responses.HEAD, good_match, status=200)
+
+    test_readme = f"""
+        {bad_url} is the place to go for more info.
+        {good_url} is better.
+        End of a sentence is ok: {good_url}.
+        Commas are fine: {good_url}, {bad_url}.
+        In parens is ok: ({good_url}).
+        {good_url}/page?x=1&y=2 is also a URL,
+        and {good_url}/page/another/ will be fine.
+        """
     all_results = {module_dict_key: {}}
     check_readme_links(test_readme, all_results)
 
     assert good_url in all_results[module_dict_key]["good_links"]
-    assert any(
-        bad.startswith("http://google.com/: Connection refused by Responses")
-        for bad in all_results[module_dict_key]["bad_links"]
-        )
+
+    bad_links = all_results[module_dict_key]["bad_links"]
+    print(bad_links)
+    assert len(bad_links) == 1
+    assert bad_links[0].startswith(f"{bad_url}: Connection refused by Responses")


### PR DESCRIPTION
We had been including trailing punctuation in URLs, so a URL at the end
of a sentence would include the period.  Now we insist that the URL end
with a word or slash.