### PR TITLE
Adding new check to get apt-get packages.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,13 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[0.1.6] - 2021-05-19
+~~~~~~~~~~~~~~~~~~~~
+
+Added
++++++++
+* Added docker file parsing check. Picking apt-get install or update packages.
+
 [0.1.5] - 2021-05-18
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/repo_health/__init__.py
+++ b/repo_health/__init__.py
@@ -9,7 +9,7 @@ import glob
 import pytest
 import dockerfile
 
-__version__ = "0.1.4"
+__version__ = "0.1.6"
 
 
 def parse_config_file(path):
@@ -74,19 +74,9 @@ def fixture_readme(repo_path):
 
 def read_docker_file(path):
     """
-    Get a list of files with given file_type in path's directory and its subdirectories
-    If the directory is large, this might take forever, so use with care
+    Read the docker file using dockerfile package.
     """
     if not os.path.exists(path):
         return None
 
     return dockerfile.parse_file(path)
-
-
-def read_docker_parse_string(search_string):
-    """
-    Get a list of files with given file_type in path's directory and its subdirectories
-    If the directory is large, this might take forever, so use with care
-    """
-    return dockerfile.parse_string(search_string)
-

--- a/repo_health/__init__.py
+++ b/repo_health/__init__.py
@@ -7,7 +7,7 @@ from configparser import ConfigParser
 from pathlib import Path
 import glob
 import pytest
-
+import dockerfile
 
 __version__ = "0.1.4"
 
@@ -70,3 +70,23 @@ def fixture_readme(repo_path):
 
     # There is no README at all, so nothing to check.
     return None
+
+
+def read_docker_file(path):
+    """
+    Get a list of files with given file_type in path's directory and its subdirectories
+    If the directory is large, this might take forever, so use with care
+    """
+    if not os.path.exists(path):
+        return None
+
+    return dockerfile.parse_file(path)
+
+
+def read_docker_parse_string(search_string):
+    """
+    Get a list of files with given file_type in path's directory and its subdirectories
+    If the directory is large, this might take forever, so use with care
+    """
+    return dockerfile.parse_string(search_string)
+

--- a/repo_health/check_ubuntufiles.py
+++ b/repo_health/check_ubuntufiles.py
@@ -90,8 +90,6 @@ def clean_data(content):
 def fixture_ubuntu_content(repo_path):
     """Fixture containing the text content of dockerfile"""
 
-    import pdb;
-    pdb.set_trace()
     return {
         'docker_packages': get_docker_file_content(repo_path),
         'apt_get_packages': get_apt_get_txt(repo_path)

--- a/repo_health/check_ubuntufiles.py
+++ b/repo_health/check_ubuntufiles.py
@@ -32,20 +32,20 @@ def get_docker_file_content(repo_path):
     if not content:
         return None
 
-    value = []
+    lists = []
 
     for con in content:
         fir, sec = False, False
         if 'RUN apt-get update' in con.original:
-            value.append(clean_data(con.original))
+            lists.append(clean_data(con.original))
             fir = True
         if 'RUN apt-get install' in con.original:
-            value.append(clean_data(con.original))
+            lists.append(clean_data(con.original))
             sec = True
         if fir and sec:  # no need to iterate after getting req data.
             break
 
-    return " ".join(value)
+    return [item for sublist in lists for item in sublist]
 
 
 def get_apt_get_txt(repo_path):
@@ -67,10 +67,22 @@ def get_apt_get_txt(repo_path):
 
 def clean_data(content):
     """
+    different number of spaces appearing in the content.
+    Replace un-necessary information.
+
     :param content:
-    :return: different number of spaces appearing in the content. So simple clean it.
+    :return: list
     """
-    content = re.sub(r"\s+", ' ', content)
+
+    content = re.sub(r"\s+", ' ', content).strip()
+    replace = [
+        'RUN', 'apt-get update', 'apt-get install', '&&', '--yes', '-rf ', 'rm', '/var/lib/apt/lists/*',
+        '--no-install-recommends', '--es', '-qy', 'upgrade', 'apt-get'
+    ]
+    for con in replace:
+        content = content.replace(con, '')
+
+    content = content.strip().split()
     return content
 
 
@@ -78,6 +90,8 @@ def clean_data(content):
 def fixture_ubuntu_content(repo_path):
     """Fixture containing the text content of dockerfile"""
 
+    import pdb;
+    pdb.set_trace()
     return {
         'docker_packages': get_docker_file_content(repo_path),
         'apt_get_packages': get_apt_get_txt(repo_path)

--- a/repo_health/check_ubuntufiles.py
+++ b/repo_health/check_ubuntufiles.py
@@ -14,9 +14,9 @@ module_dict_key = "ubuntu_packages"
 
 def get_docker_file_content(repo_path):
     """
-   entry point to read parse and read dependencies
+   entry point to parse docker file and do cleaning.
    @param repo_path:
-   @return: json data.
+   @return: json data
    """
     content = None
 
@@ -43,7 +43,7 @@ def get_docker_file_content(repo_path):
         if fir and sec:  # no need to iterate after getting req data.
             break
 
-    return {"docker": " ".join(value)}
+    return " ".join(value)
 
 
 def clean_data(content):

--- a/repo_health/check_ubuntufiles.py
+++ b/repo_health/check_ubuntufiles.py
@@ -87,10 +87,13 @@ def fixture_ubuntu_content(repo_path):
 @health_metadata(
     [module_dict_key],
     {
-        "ubuntu_packages": "content name published on ubuntu."
+        "docker_packages": "content name published on ubuntu.",
+        "apt_get_packages": "content name published on ubuntu."
     })
 def check_ubuntu_content(content, all_results):
     """
     Adding data into results.
     """
-    all_results[module_dict_key] = content
+    import pdb;
+    pdb.set_trace()
+    all_results.update(content)

--- a/repo_health/check_ubuntufiles.py
+++ b/repo_health/check_ubuntufiles.py
@@ -1,16 +1,15 @@
 """
 Checks Dockerfile in the repo, and try to parse out packages installed via apt-get install and update.
+Also check the apt-packages.txt content.
 """
 import os
 import re
+from pathlib import Path
 
 import pytest
 from pytest_repo_health import health_metadata
 
-from repo_health import read_docker_file
-from pathlib import Path
-from repo_health import get_file_lines
-
+from repo_health import get_file_lines, read_docker_file
 
 module_dict_key = "ubuntu_packages"
 
@@ -51,7 +50,7 @@ def get_docker_file_content(repo_path):
 
 def get_apt_get_txt(repo_path):
     """
-   entry point to parse docker file and do cleaning.
+   entry point to parse apt-packages.txt.
    @param repo_path:
    @return: json data
    """

--- a/repo_health/check_ubuntufiles.py
+++ b/repo_health/check_ubuntufiles.py
@@ -1,13 +1,14 @@
 """
-Checks package published name on npm.
+Checks Dockerfile in the repo, and try to parse out packages installed via apt-get install and update.
 """
-import json
 import os
+import re
 
 import pytest
 from pytest_repo_health import health_metadata
 
-from repo_health import read_docker_file, read_docker_parse_string
+from repo_health import read_docker_file
+
 module_dict_key = "ubuntu_packages"
 
 
@@ -17,44 +18,56 @@ def get_docker_file_content(repo_path):
    @param repo_path:
    @return: json data.
    """
+    content = None
 
-    # in credentials `Dockerfile-testing` name exists
     for file in ['Dockerfile', 'Dockerfile-testing', 'Dockerfile-3.8']:
         full_path = os.path.join(repo_path, file)
-        content = read_docker_file(full_path)
-        if content:
-            break
+        if os.path.exists(full_path):
+            content = read_docker_file(full_path)
+            if content:
+                break
 
     if not content:
-        return
+        return None
 
     value = []
+
     for con in content:
-        fir,sec = False, False
+        fir, sec = False, False
         if 'RUN apt-get update' in con.original:
-            value.append(con.original)
+            value.append(clean_data(con.original))
             fir = True
         if 'RUN apt-get install' in con.original:
-            value.append(con.original)
+            value.append(clean_data(con.original))
             sec = True
-        if fir and sec:
+        if fir and sec:  # no need to iterate after getting req data.
             break
-    return value
+
+    return {"docker": " ".join(value)}
+
+
+def clean_data(content):
+    """
+    :param content:
+    :return: different number of spaces appearing in the content. So simple clean it.
+    """
+    content = re.sub(r"\s+", ' ', content)
+    return content
 
 
 @pytest.fixture(name='content')
-def fixture_npm_package(repo_path):
-    """Fixture containing the text content of package.json"""
+def fixture_ubuntu_content(repo_path):
+    """Fixture containing the text content of dockerfile"""
     return get_docker_file_content(repo_path)
 
 
 @health_metadata(
     [module_dict_key],
     {
-        "ubuntu_packages": "package name published on npm."
+        "ubuntu_packages": "content name published on ubuntu."
     })
-def check_npm_package(content, all_results):
+def check_ubuntu_content(content, all_results):
     """
-    verify pattern on npm site where package has prefix @edx/.
+    Adding data into results.
     """
     all_results[module_dict_key] = content

--- a/repo_health/check_ubuntufiles.py
+++ b/repo_health/check_ubuntufiles.py
@@ -8,6 +8,9 @@ import pytest
 from pytest_repo_health import health_metadata
 
 from repo_health import read_docker_file
+from pathlib import Path
+from repo_health import get_file_lines
+
 
 module_dict_key = "ubuntu_packages"
 
@@ -46,6 +49,23 @@ def get_docker_file_content(repo_path):
     return " ".join(value)
 
 
+def get_apt_get_txt(repo_path):
+    """
+   entry point to parse docker file and do cleaning.
+   @param repo_path:
+   @return: json data
+   """
+    full_path = os.path.join(repo_path, 'apt-packages.txt')
+    # check files on root or in requirements folder
+    content = get_file_lines(full_path)
+    if not content:
+        files = [str(file) for file in Path(os.path.join(repo_path, "requirements")).rglob('apt-packages.txt')]
+        if files:
+            content = get_file_lines(files[0])  # only one file will exists
+
+    return content
+
+
 def clean_data(content):
     """
     :param content:
@@ -58,7 +78,11 @@ def clean_data(content):
 @pytest.fixture(name='content')
 def fixture_ubuntu_content(repo_path):
     """Fixture containing the text content of dockerfile"""
-    return get_docker_file_content(repo_path)
+
+    return {
+        'docker_packages': get_docker_file_content(repo_path),
+        'apt_get_packages': get_apt_get_txt(repo_path)
+    }
 
 
 @health_metadata(

--- a/repo_health/check_ubuntufiles.py
+++ b/repo_health/check_ubuntufiles.py
@@ -1,0 +1,60 @@
+"""
+Checks package published name on npm.
+"""
+import json
+import os
+
+import pytest
+from pytest_repo_health import health_metadata
+
+from repo_health import read_docker_file, read_docker_parse_string
+module_dict_key = "ubuntu_packages"
+
+
+def get_docker_file_content(repo_path):
+    """
+   entry point to read parse and read dependencies
+   @param repo_path:
+   @return: json data.
+   """
+
+    # in credentials `Dockerfile-testing` name exists
+    for file in ['Dockerfile', 'Dockerfile-testing', 'Dockerfile-3.8']:
+        full_path = os.path.join(repo_path, file)
+        content = read_docker_file(full_path)
+        if content:
+            break
+
+    if not content:
+        return
+
+    value = []
+    for con in content:
+        fir,sec = False, False
+        if 'RUN apt-get update' in con.original:
+            value.append(con.original)
+            fir = True
+        if 'RUN apt-get install' in con.original:
+            value.append(con.original)
+            sec = True
+        if fir and sec:
+            break
+    return value
+
+
+@pytest.fixture(name='content')
+def fixture_npm_package(repo_path):
+    """Fixture containing the text content of package.json"""
+    return get_docker_file_content(repo_path)
+
+
+@health_metadata(
+    [module_dict_key],
+    {
+        "ubuntu_packages": "package name published on npm."
+    })
+def check_npm_package(content, all_results):
+    """
+    verify pattern on npm site where package has prefix @edx/.
+    """
+    all_results[module_dict_key] = content

--- a/repo_health/check_ubuntufiles.py
+++ b/repo_health/check_ubuntufiles.py
@@ -94,6 +94,4 @@ def check_ubuntu_content(content, all_results):
     """
     Adding data into results.
     """
-    import pdb;
-    pdb.set_trace()
     all_results.update(content)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -5,3 +5,5 @@
 gspread                    # Access information from Google Sheets (the ownership spreadsheet)
 pyyaml                     # Read and write YAML files
 pytest-repo-health         # plugin used to run the checks in this repo
+dockerfile                 # wrapper around docker/docker's parser for dockerfiles.
+

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ aiohttp==3.7.4.post0
     #   pytest-aiohttp
 async-timeout==3.0.1
     # via aiohttp
-attrs==21.1.0
+attrs==21.2.0
     # via
     #   aiohttp
     #   pytest
@@ -23,11 +23,13 @@ chardet==3.0.4
     #   -c requirements/constraints.txt
     #   aiohttp
     #   requests
+dockerfile==3.1.0
+    # via -r requirements/base.in
 gitdb==4.0.7
     # via gitpython
 git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140
     # via -r requirements/github.in
-gitpython==3.1.14
+gitpython==3.1.17
     # via pytest-repo-health
 google-auth-oauthlib==0.4.4
     # via gspread
@@ -37,18 +39,10 @@ google-auth==1.30.0
     #   gspread
 gspread==3.7.0
     # via -r requirements/base.in
-idna-ssl==1.1.0
-    # via aiohttp
 idna==2.10
     # via
-    #   idna-ssl
     #   requests
     #   yarl
-importlib-metadata==2.1.1
-    # via
-    #   -c requirements/constraints.txt
-    #   pluggy
-    #   pytest
 iniconfig==1.1.1
     # via pytest
 multidict==5.1.0
@@ -96,15 +90,11 @@ smmap==4.0.0
 toml==0.10.2
     # via pytest
 typing-extensions==3.10.0.0
-    # via
-    #   aiohttp
-    #   yarl
+    # via aiohttp
 urllib3==1.26.4
     # via requests
 yarl==1.6.3
     # via aiohttp
-zipp==3.4.1
-    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -24,14 +24,6 @@ filelock==3.0.12
     #   virtualenv
 idna==2.10
     # via requests
-importlib-metadata==2.1.1
-    # via
-    #   -c requirements/constraints.txt
-    #   pluggy
-    #   tox
-    #   virtualenv
-importlib-resources==5.1.2
-    # via virtualenv
 packaging==20.9
     # via tox
 pluggy==0.13.1
@@ -54,7 +46,3 @@ urllib3==1.26.4
     # via requests
 virtualenv==20.4.6
     # via tox
-zipp==3.4.1
-    # via
-    #   importlib-metadata
-    #   importlib-resources

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -22,7 +22,7 @@ async-timeout==3.0.1
     # via
     #   -r requirements/quality.txt
     #   aiohttp
-attrs==21.1.0
+attrs==21.2.0
     # via
     #   -r requirements/quality.txt
     #   aiohttp
@@ -49,6 +49,7 @@ click-log==0.3.2
     #   edx-lint
 click==7.1.2
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
     #   click-log
@@ -73,12 +74,14 @@ distlib==0.3.1
     # via
     #   -r requirements/ci.txt
     #   virtualenv
-django==2.2.22
+django==2.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
     #   code-annotations
     #   edx-lint
+dockerfile==3.1.0
+    # via -r requirements/quality.txt
 edx-lint==5.0.0
     # via -r requirements/quality.txt
 filelock==3.0.12
@@ -92,7 +95,7 @@ gitdb==4.0.7
     #   gitpython
 git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140
     # via -r requirements/quality.txt
-gitpython==3.1.14
+gitpython==3.1.17
     # via
     #   -r requirements/quality.txt
     #   pytest-repo-health
@@ -107,33 +110,12 @@ google-auth==1.30.0
     #   gspread
 gspread==3.7.0
     # via -r requirements/quality.txt
-idna-ssl==1.1.0
-    # via
-    #   -r requirements/quality.txt
-    #   aiohttp
 idna==2.10
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
-    #   idna-ssl
     #   requests
     #   yarl
-importlib-metadata==2.1.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/ci.txt
-    #   -r requirements/pip-tools.txt
-    #   -r requirements/quality.txt
-    #   pep517
-    #   pluggy
-    #   pytest
-    #   stevedore
-    #   tox
-    #   virtualenv
-importlib-resources==5.1.2
-    # via
-    #   -r requirements/ci.txt
-    #   virtualenv
 inflect==5.3.0
     # via jinja2-pluralize
 iniconfig==1.1.1
@@ -148,6 +130,7 @@ jinja2-pluralize==0.3.0
     # via diff-cover
 jinja2==2.11.3
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
     #   code-annotations
     #   diff-cover
@@ -158,6 +141,7 @@ lazy-object-proxy==1.6.0
     #   astroid
 markupsafe==1.1.1
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
     #   jinja2
 mccabe==0.6.1
@@ -213,7 +197,7 @@ pyasn1==0.4.8
     #   rsa
 pycodestyle==2.7.0
     # via -r requirements/quality.txt
-pydocstyle==6.0.0
+pydocstyle==6.1.1
     # via -r requirements/quality.txt
 pygments==2.9.0
     # via diff-cover
@@ -327,15 +311,10 @@ tox==3.23.1
     # via
     #   -r requirements/ci.txt
     #   tox-battery
-typed-ast==1.4.3
-    # via
-    #   -r requirements/quality.txt
-    #   astroid
 typing-extensions==3.10.0.0
     # via
     #   -r requirements/quality.txt
     #   aiohttp
-    #   yarl
 urllib3==1.26.4
     # via
     #   -r requirements/ci.txt
@@ -354,14 +333,6 @@ yarl==1.6.3
     # via
     #   -r requirements/quality.txt
     #   aiohttp
-zipp==3.4.1
-    # via
-    #   -r requirements/ci.txt
-    #   -r requirements/pip-tools.txt
-    #   -r requirements/quality.txt
-    #   importlib-metadata
-    #   importlib-resources
-    #   pep517
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -15,7 +15,7 @@ async-timeout==3.0.1
     # via
     #   -r requirements/test.txt
     #   aiohttp
-attrs==21.1.0
+attrs==21.2.0
     # via
     #   -r requirements/test.txt
     #   aiohttp
@@ -41,6 +41,8 @@ chardet==3.0.4
     #   requests
 doc8==0.8.1
     # via -r requirements/doc.in
+dockerfile==3.1.0
+    # via -r requirements/test.txt
 docutils==0.16
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
@@ -56,7 +58,7 @@ gitdb==4.0.7
     #   gitpython
 git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140
     # via -r requirements/test.txt
-gitpython==3.1.14
+gitpython==3.1.17
     # via
     #   -r requirements/test.txt
     #   pytest-repo-health
@@ -71,33 +73,26 @@ google-auth==1.30.0
     #   gspread
 gspread==3.7.0
     # via -r requirements/test.txt
-idna-ssl==1.1.0
-    # via
-    #   -r requirements/test.txt
-    #   aiohttp
 idna==2.10
     # via
     #   -r requirements/test.txt
-    #   idna-ssl
     #   requests
     #   yarl
 imagesize==1.2.0
     # via sphinx
-importlib-metadata==2.1.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
-    #   pluggy
-    #   pytest
-    #   stevedore
 iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
     #   pytest
 jinja2==2.11.3
-    # via sphinx
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   sphinx
 markupsafe==1.1.1
-    # via jinja2
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   jinja2
+    #   sphinx
 multidict==5.1.0
     # via
     #   -r requirements/test.txt
@@ -193,7 +188,7 @@ smmap==4.0.0
     #   gitdb
 snowballstemmer==2.1.0
     # via sphinx
-sphinx==3.5.4
+sphinx==4.0.1
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme
@@ -219,7 +214,6 @@ typing-extensions==3.10.0.0
     # via
     #   -r requirements/test.txt
     #   aiohttp
-    #   yarl
 urllib3==1.26.4
     # via
     #   -r requirements/test.txt
@@ -231,10 +225,6 @@ yarl==1.6.3
     # via
     #   -r requirements/test.txt
     #   aiohttp
-zipp==3.4.1
-    # via
-    #   -r requirements/test.txt
-    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,21 +5,15 @@
 #    make upgrade
 #
 click==7.1.2
-    # via pip-tools
-importlib-metadata==2.1.1
     # via
-    #   -c requirements/constraints.txt
-    #   pep517
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   pip-tools
 pep517==0.10.0
     # via pip-tools
 pip-tools==6.1.0
     # via -r requirements/pip-tools.in
 toml==0.10.2
     # via pep517
-zipp==3.4.1
-    # via
-    #   importlib-metadata
-    #   pep517
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -10,5 +10,5 @@ wheel==0.36.2
 # The following packages are considered to be unsafe in a requirements file:
 pip==21.1.1
     # via -r requirements/pip.in
-setuptools==56.1.0
+setuptools==56.2.0
     # via -r requirements/pip.in

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -17,7 +17,7 @@ async-timeout==3.0.1
     # via
     #   -r requirements/test.txt
     #   aiohttp
-attrs==21.1.0
+attrs==21.2.0
     # via
     #   -r requirements/test.txt
     #   aiohttp
@@ -40,16 +40,19 @@ click-log==0.3.2
     # via edx-lint
 click==7.1.2
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   click-log
     #   code-annotations
     #   edx-lint
 code-annotations==1.1.1
     # via edx-lint
-django==2.2.22
+django==2.2.23
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   code-annotations
     #   edx-lint
+dockerfile==3.1.0
+    # via -r requirements/test.txt
 edx-lint==5.0.0
     # via -r requirements/quality.in
 gitdb==4.0.7
@@ -58,7 +61,7 @@ gitdb==4.0.7
     #   gitpython
 git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140
     # via -r requirements/test.txt
-gitpython==3.1.14
+gitpython==3.1.17
     # via
     #   -r requirements/test.txt
     #   pytest-repo-health
@@ -73,23 +76,11 @@ google-auth==1.30.0
     #   gspread
 gspread==3.7.0
     # via -r requirements/test.txt
-idna-ssl==1.1.0
-    # via
-    #   -r requirements/test.txt
-    #   aiohttp
 idna==2.10
     # via
     #   -r requirements/test.txt
-    #   idna-ssl
     #   requests
     #   yarl
-importlib-metadata==2.1.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/test.txt
-    #   pluggy
-    #   pytest
-    #   stevedore
 iniconfig==1.1.1
     # via
     #   -r requirements/test.txt
@@ -99,11 +90,15 @@ isort==5.8.0
     #   -r requirements/quality.in
     #   pylint
 jinja2==2.11.3
-    # via code-annotations
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   code-annotations
 lazy-object-proxy==1.6.0
     # via astroid
 markupsafe==1.1.1
-    # via jinja2
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   jinja2
 mccabe==0.6.1
     # via pylint
 multidict==5.1.0
@@ -140,7 +135,7 @@ pyasn1==0.4.8
     #   rsa
 pycodestyle==2.7.0
     # via -r requirements/quality.in
-pydocstyle==6.0.0
+pydocstyle==6.1.1
     # via -r requirements/quality.in
 pylint-celery==0.3
     # via edx-lint
@@ -218,13 +213,10 @@ toml==0.10.2
     #   -r requirements/test.txt
     #   pylint
     #   pytest
-typed-ast==1.4.3
-    # via astroid
 typing-extensions==3.10.0.0
     # via
     #   -r requirements/test.txt
     #   aiohttp
-    #   yarl
 urllib3==1.26.4
     # via
     #   -r requirements/test.txt
@@ -236,10 +228,6 @@ yarl==1.6.3
     # via
     #   -r requirements/test.txt
     #   aiohttp
-zipp==3.4.1
-    # via
-    #   -r requirements/test.txt
-    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -13,7 +13,7 @@ async-timeout==3.0.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
-attrs==21.1.0
+attrs==21.2.0
     # via
     #   -r requirements/base.txt
     #   aiohttp
@@ -32,13 +32,15 @@ chardet==3.0.4
     #   -r requirements/base.txt
     #   aiohttp
     #   requests
+dockerfile==3.1.0
+    # via -r requirements/base.txt
 gitdb==4.0.7
     # via
     #   -r requirements/base.txt
     #   gitpython
 git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3c35cef6#egg=github.py==1.0.0a495+g8e35140
     # via -r requirements/base.txt
-gitpython==3.1.14
+gitpython==3.1.17
     # via
     #   -r requirements/base.txt
     #   pytest-repo-health
@@ -53,22 +55,11 @@ google-auth==1.30.0
     #   gspread
 gspread==3.7.0
     # via -r requirements/base.txt
-idna-ssl==1.1.0
-    # via
-    #   -r requirements/base.txt
-    #   aiohttp
 idna==2.10
     # via
     #   -r requirements/base.txt
-    #   idna-ssl
     #   requests
     #   yarl
-importlib-metadata==2.1.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
-    #   pluggy
-    #   pytest
 iniconfig==1.1.1
     # via
     #   -r requirements/base.txt
@@ -154,7 +145,6 @@ typing-extensions==3.10.0.0
     # via
     #   -r requirements/base.txt
     #   aiohttp
-    #   yarl
 urllib3==1.26.4
     # via
     #   -r requirements/base.txt
@@ -164,10 +154,6 @@ yarl==1.6.3
     # via
     #   -r requirements/base.txt
     #   aiohttp
-zipp==3.4.1
-    # via
-    #   -r requirements/base.txt
-    #   importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/tests/fake_repos/kodegail/Dockerfile
+++ b/tests/fake_repos/kodegail/Dockerfile
@@ -1,0 +1,1 @@
+testing

--- a/tests/fake_repos/python_js_repo/Dockerfile-testing
+++ b/tests/fake_repos/python_js_repo/Dockerfile-testing
@@ -1,0 +1,50 @@
+FROM ubuntu:focal as base
+
+# Warning: This file is experimental.
+
+# Install system requirements
+RUN apt-get update && \
+    # Global requirements
+    DEBIAN_FRONTEND=noninteractive apt-get install --yes \
+    build-essential \
+    curl \
+    # If we don't need gcc, we should remove it.
+    g++ \
+    gcc \
+    git \
+    git-core \
+    language-pack-en \
+    libfreetype6-dev \
+    libmysqlclient-dev \
+    libssl-dev \
+    libxml2-dev \
+    libxmlsec1-dev \
+    libxslt1-dev \
+    swig \
+    # openedx requirements
+    gettext \
+    gfortran \
+    graphviz \
+    libffi-dev \
+    libfreetype6-dev \
+    libgeos-dev \
+    libgraphviz-dev \
+    libjpeg8-dev \
+    liblapack-dev \
+    libpng-dev \
+    libsqlite3-dev \
+    libxml2-dev \
+    libxmlsec1-dev \
+    libxslt1-dev \
+    # lynx: Required by https://github.com/edx/edx-platform/blob/b489a4ecb122/openedx/core/lib/html_to_text.py#L16
+    lynx \
+    ntp \
+    pkg-config \
+    python3-dev \
+    python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8

--- a/tests/fake_repos/python_js_repo/apt-packages.txt
+++ b/tests/fake_repos/python_js_repo/apt-packages.txt
@@ -1,0 +1,3 @@
+python-virtualenv
+python-scipy
+python-numpy

--- a/tests/fake_repos/python_repo/Dockerfile
+++ b/tests/fake_repos/python_repo/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:focal as app
+
+# System requirements.
+RUN apt-get update && apt-get upgrade -qy
+RUN apt-get install -qy \
+	git-core \
+	language-pack-en \
+	python3.8 \
+	python3-pip \
+	python3.8-dev \
+	libmysqlclient-dev \
+	libssl-dev
+RUN pip3 install --upgrade pip setuptools
+RUN rm -rf /var/lib/apt/lists/*
+
+# Python is Python3.
+RUN ln -s /usr/bin/pip3 /usr/bin/pip
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+# Use UTF-8.
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8

--- a/tests/fake_repos/python_repo/requirements/ubuntu/apt-packages.txt
+++ b/tests/fake_repos/python_repo/requirements/ubuntu/apt-packages.txt
@@ -1,0 +1,12 @@
+python-software-properties
+pkg-config
+gfortran
+libatlas-dev
+libblas-dev
+liblapack-dev
+liblapack3gf
+curl
+git
+python-virtualenv
+python-scipy
+python-numpy

--- a/tests/test_ubuntu_dependencies.py
+++ b/tests/test_ubuntu_dependencies.py
@@ -1,6 +1,6 @@
 import os
 
-from repo_health.check_ubuntufiles import get_docker_file_content
+from repo_health.check_ubuntufiles import get_apt_get_txt, get_docker_file_content
 
 
 def get_repo_path(repo_name):
@@ -35,3 +35,20 @@ def test_docker_new_format():
     assert 'git-core' in dependencies
     assert 'curl' in dependencies
 
+
+def test_loading_apt_packages_txt():
+    repo_path = get_repo_path('fake_repos/python_repo')
+    dependencies = get_apt_get_txt(repo_path)
+    assert 'curl' in dependencies
+
+
+def test_loading_apt_packages_txt_root_path():
+    repo_path = get_repo_path('fake_repos/python_js_repo')
+    dependencies = get_apt_get_txt(repo_path)
+    assert 'python-numpy' in dependencies
+
+
+def test_not_available_apt_packages_txt():
+    repo_path = get_repo_path('fake_repos/js_repo')
+    dependencies = get_apt_get_txt(repo_path)
+    assert dependencies == []

--- a/tests/test_ubuntu_dependencies.py
+++ b/tests/test_ubuntu_dependencies.py
@@ -11,10 +11,10 @@ def get_repo_path(repo_name):
 def test_loading_docker_file_check():
     repo_path = get_repo_path('fake_repos/python_repo')
     dependencies = get_docker_file_content(repo_path)
-    assert 'apt-get install' in dependencies['docker']
-    assert 'apt-get update' in dependencies['docker']
-    assert 'python3-pip' in dependencies['docker']
-    assert 'libssl-dev' in dependencies['docker']
+    assert 'apt-get install' in dependencies
+    assert 'apt-get update' in dependencies
+    assert 'python3-pip' in dependencies
+    assert 'libssl-dev' in dependencies
 
 
 def test_no_docker_file_check():
@@ -30,7 +30,8 @@ def test_empty_docker_file_check():
 def test_docker_new_format():
     repo_path = get_repo_path('fake_repos/python_js_repo')
     dependencies = get_docker_file_content(repo_path)
-    assert 'apt-get install' in dependencies['docker']
-    assert 'apt-get update' in dependencies['docker']
-    assert 'git-core' in dependencies['docker']
-    assert 'curl' in dependencies['docker']
+    assert 'apt-get install' in dependencies
+    assert 'apt-get update' in dependencies
+    assert 'git-core' in dependencies
+    assert 'curl' in dependencies
+

--- a/tests/test_ubuntu_dependencies.py
+++ b/tests/test_ubuntu_dependencies.py
@@ -11,10 +11,9 @@ def get_repo_path(repo_name):
 def test_loading_docker_file_check():
     repo_path = get_repo_path('fake_repos/python_repo')
     dependencies = get_docker_file_content(repo_path)
-    assert 'apt-get install' in dependencies
-    assert 'apt-get update' in dependencies
-    assert 'python3-pip' in dependencies
     assert 'libssl-dev' in dependencies
+    for data in ['git-core', 'language-pack-en', 'python3.8', 'python3-pip', 'libssl-dev']:
+        assert data in dependencies
 
 
 def test_no_docker_file_check():
@@ -27,12 +26,9 @@ def test_empty_docker_file_check():
     assert get_docker_file_content(repo_path) is None
 
 
-def test_docker_new_format():
+def test_docker_different_format():
     repo_path = get_repo_path('fake_repos/python_js_repo')
     dependencies = get_docker_file_content(repo_path)
-    assert 'apt-get install' in dependencies
-    assert 'apt-get update' in dependencies
-    assert 'git-core' in dependencies
     assert 'curl' in dependencies
 
 

--- a/tests/test_ubuntu_dependencies.py
+++ b/tests/test_ubuntu_dependencies.py
@@ -1,0 +1,36 @@
+import os
+
+from repo_health.check_ubuntufiles import get_docker_file_content
+
+
+def get_repo_path(repo_name):
+    tests_directory = os.path.dirname(__file__)
+    return f"{tests_directory}/{repo_name}"
+
+
+def test_loading_docker_file_check():
+    repo_path = get_repo_path('fake_repos/python_repo')
+    dependencies = get_docker_file_content(repo_path)
+    assert 'apt-get install' in dependencies['docker']
+    assert 'apt-get update' in dependencies['docker']
+    assert 'python3-pip' in dependencies['docker']
+    assert 'libssl-dev' in dependencies['docker']
+
+
+def test_no_docker_file_check():
+    repo_path = get_repo_path('fake_repos/docs_repo')
+    assert get_docker_file_content(repo_path) is None
+
+
+def test_empty_docker_file_check():
+    repo_path = get_repo_path('fake_repos/kodejail')
+    assert get_docker_file_content(repo_path) is None
+
+
+def test_docker_new_format():
+    repo_path = get_repo_path('fake_repos/python_js_repo')
+    dependencies = get_docker_file_content(repo_path)
+    assert 'apt-get install' in dependencies['docker']
+    assert 'apt-get update' in dependencies['docker']
+    assert 'git-core' in dependencies['docker']
+    assert 'curl' in dependencies['docker']


### PR DESCRIPTION
Part1:

Adding new check to get docker apt-get packages
https://openedx.atlassian.net/browse/BOM-2537

This ticket has several parts I will implement in small parts.

- apt-packages.txt in the repo, and add any lines found in them.
- look for any files named Dockerfile in the repo, and try to parse out packages installed via apt-get install or update.

`edx-platform` data.
```
docker_packages:
- DEBIAN_FRONTEND=noninteractive
- build-essential
- curl
- g++
- gcc
- git
- git-core
- language-pack-en
- libfreetype6-dev
- libmysqlclient-dev
- libssl-dev
- libxml2-dev
- libxmlsec1-dev
- libxslt1-dev
- swig
- gettext
- gfortran
- graphviz
- libffi-dev
- libfreetype6-dev
- libgeos-dev
- libgraphviz-dev
- libjpeg8-dev
- liblapack-dev
- libpng-dev
- libsqlite3-dev
- libxml2-dev
- libxmlsec1-dev
- libxslt1-dev
- lynx
- ntp
- pkg-config
- python3-dev
- python3-venv
```

```
apt_get_packages:
- python-software-properties
- pkg-config
- gfortran
- libatlas-dev
- libblas-dev
- liblapack-dev
- liblapack3gf
- curl
- git
- python-virtualenv
- python-scipy
- python-numpy
- build-essential
- python-dev
- gfortran
- libfreetype6-dev
- libpng12-dev
- libjpeg-dev
- libtiff4-dev
- zlib1g-dev
- libxml2-dev
- libxslt-dev
- yui-compressor
- graphviz
- libgraphviz-dev
- graphviz-dev
- mysql-server
- libmysqlclient-dev
- libgeos-dev
- libreadline6
- libreadline6-dev
- mongodb
- nodejs
- mysql-client
- virtualenvwrapper
- libgeos-ruby1.8
- lynx-cur
- libxmlsec1-dev
- swig
```