### PR TITLE
All JS Dependencies From package-lock.json

### DIFF
--- a/repo_health/check_dependencies.py
+++ b/repo_health/check_dependencies.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from pytest_repo_health import health_metadata
 
-from repo_health import get_file_lines
+from repo_health import get_file_lines, get_file_content
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +36,10 @@ default_output = {
         "list": "",
     },
     "js.dev": {
+        "count": 0,
+        "list": ""
+    },
+    "js.all": {
         "count": 0,
         "list": ""
     }
@@ -86,6 +90,12 @@ class JavascriptDependencyReader(DependencyReader):
         self.js_dependencies_count = len(self.js_dependencies)
         self.js_dev_dependencies_count = len(self.js_dev_dependencies)
 
+        package_lock_content = get_file_content(os.path.join(self._repo_path, "package-lock.json"))
+        if package_lock_content:
+            package_lock_data = json.loads(package_lock_content)
+            for dependency, details in package_lock_data.get('dependencies', {}).items():
+                self.js_dependencies_all[dependency] = details["version"]
+
         return {
             "count": self.js_dependencies_count + self.js_dev_dependencies_count,
             "js": {
@@ -95,6 +105,10 @@ class JavascriptDependencyReader(DependencyReader):
             "js.dev": {
                 "count": self.js_dev_dependencies_count,
                 "list": json.dumps(self.js_dev_dependencies)
+            },
+            "js.all": {
+                "count": len(self.js_dependencies_all),
+                "list": json.dumps(self.js_dependencies_all)
             }
         }
 

--- a/tests/test_check_dependencies.py
+++ b/tests/test_check_dependencies.py
@@ -17,6 +17,7 @@ def test_python_js_repo_dependency_check():
     assert dependencies["count"] == 350
     assert dependencies["pypi_all"]["count"] == 299
     assert dependencies["github"]["count"] == 14
+    assert dependencies["js.all"]["count"] == 10
     assert dependencies["js"]["count"] == 26
     assert dependencies["pypi"]["count"] == 225
 
@@ -27,11 +28,13 @@ def test_js_repo_dependency_check():
 
     assert 'core-js' in dependencies["js"]["list"]
     assert 'jest' in dependencies["js.dev"]["list"]
+    assert 'babel' in dependencies["js.all"]["list"]
 
     assert dependencies["count"] == 37
     assert dependencies["js"]["count"] == 26
     assert dependencies["js.dev"]["count"] == 11
     assert dependencies["pypi_all"]["count"] == 0
+    assert dependencies["js.all"]["count"] == 12
     assert dependencies["pypi"]["count"] == 0
 
 


### PR DESCRIPTION
Excluded the column from being pushed to google sheets here https://github.com/edx/repo-health-data/pull/32, so we can revert this.

Reverts edx/edx-repo-health#170