### PR TITLE
feat: hardcoding in license info for some repositories

### DIFF
--- a/repo_health/check_github.py
+++ b/repo_health/check_github.py
@@ -114,8 +114,14 @@ async def check_build_duration(all_results, github_repo):
 # unfortunatly, some repositories don't set their license in a way that does not work in licensee.
 # repo_license_exemtions is used to fill in license info for these repositories
 # it documents: (repo name, license name, link to more info to reupdate list in the future, org (owner) name)
-repo_license_exemptions = {"gocd-vault-secret-plugin": {'license':"Apache License 2.0", "more_info":"https://github.com/edx/gocd-vault-secret-plugin/blob/aaa5de944c599a0df7469b731e7fe1feb1451636/.idea/copyright/Apache_2_0.xml", "owner": "edx"},
-                               }
+repo_license_exemptions = {
+    "gocd-vault-secret-plugin": {
+        "license": "Apache License 2.0",
+        "more_info": "https://github.com/edx/gocd-vault-secret-plugin/blob/aaa5de944c599a0df7469b731e7fe1feb1451636/.idea/copyright/Apache_2_0.xml",
+        "owner": "edx",
+    },
+}
+
 
 @health_metadata(
     [MODULE_DICT_KEY],
@@ -174,8 +180,12 @@ async def check_settings(all_results, github_repo):
     results["last_push"] = github_repo.pushed_at
     repo_license = github_repo.license
     if repo_license is None:
-        if github_repo.name in repo_license_exemptions and github_repo.owner.login == repo_license_exemptions[github_repo.name]["owner"]:
-            results["license"] = repo_license_exemptions[github_repo.name]['license']
+        if (
+            github_repo.name in repo_license_exemptions
+            and github_repo.owner.login
+            == repo_license_exemptions[github_repo.name]["owner"]
+        ):
+            results["license"] = repo_license_exemptions[github_repo.name]["license"]
         else:
             results["license"] = None
     else:

--- a/repo_health/check_github.py
+++ b/repo_health/check_github.py
@@ -110,6 +110,12 @@ async def check_build_duration(all_results, github_repo):
         'checks': checks_list
     })
 
+# github uses licensee/licensee to figure out the license of a git repository: https://licensee.github.io/licensee/
+# unfortunatly, some repositories don't set their license in a way that does not work in licensee.
+# repo_license_exemtions is used to fill in license info for these repositories
+# it documents: (repo name, license name, link to more info to reupdate list in the future)
+repo_license_exemptions = {"gocd-vault-secret-plugin": {'license':"Apache License 2.0", "more_info":"https://github.com/gocd/gocd-vault-secret-plugin/blob/master/.idea/copyright/Apache_2_0.xml"},
+                               }
 
 @health_metadata(
     [MODULE_DICT_KEY],
@@ -168,7 +174,11 @@ async def check_settings(all_results, github_repo):
     results["last_push"] = github_repo.pushed_at
     repo_license = github_repo.license
     if repo_license is None:
-        results["license"] = None
+        if github_repo.name in repo_license_exemptions:
+            results["license"] = repo_license_exemptions[github_repo.name]['license']
+            breakpoint()
+        else:
+            results["license"] = None
     else:
         results["license"] = repo_license.nickname or repo_license.name
 

--- a/repo_health/check_github.py
+++ b/repo_health/check_github.py
@@ -113,7 +113,7 @@ async def check_build_duration(all_results, github_repo):
 # GitHub uses https://licensee.github.io/licensee/ to figure out the license of a git repository.
 # Unfortunately, some repositories set their license in a way that does not work with `licensee`.
 # repo_license_exemptions is used to fill in license info for these repositories.
-# it documents: (repo name, license name, link to more info to reupdate list in the future, org (owner) name)
+# it documents: (repo name, license name, more info (link to license), owner (repo org))
 repo_license_exemptions = {
     "gocd-vault-secret-plugin": {
         "license": "Apache License 2.0",

--- a/repo_health/check_github.py
+++ b/repo_health/check_github.py
@@ -114,10 +114,11 @@ async def check_build_duration(all_results, github_repo):
 # Unfortunately, some repositories set their license in a way that does not work with `licensee`.
 # repo_license_exemptions is used to fill in license info for these repositories.
 # it documents: (repo name, license name, more info (link to license), owner (repo org))
+# Since edx/edx-repo-health is a public repository, info about private repositories should not be added here without some deliberation
 repo_license_exemptions = {
     "gocd-vault-secret-plugin": {
         "license": "Apache License 2.0",
-        "more_info": "https://github.com/edx/gocd-vault-secret-plugin/blob/aaa5de944c599a0df7469b731e7fe1feb1451636/.idea/copyright/Apache_2_0.xml",
+        "more_info": "https://github.com/edx/gocd-vault-secret-plugin/blob/v1.2.0-66-exp/.idea/copyright/Apache_2_0.xml",
         "owner": "edx",
     },
 }

--- a/repo_health/check_github.py
+++ b/repo_health/check_github.py
@@ -182,8 +182,7 @@ async def check_settings(all_results, github_repo):
     if repo_license is None:
         if (
             github_repo.name in repo_license_exemptions
-            and github_repo.owner.login
-            == repo_license_exemptions[github_repo.name]["owner"]
+            and github_repo.owner.login == repo_license_exemptions[github_repo.name]["owner"]
         ):
             results["license"] = repo_license_exemptions[github_repo.name]["license"]
         else:

--- a/repo_health/check_github.py
+++ b/repo_health/check_github.py
@@ -113,8 +113,8 @@ async def check_build_duration(all_results, github_repo):
 # github uses licensee/licensee to figure out the license of a git repository: https://licensee.github.io/licensee/
 # unfortunatly, some repositories don't set their license in a way that does not work in licensee.
 # repo_license_exemtions is used to fill in license info for these repositories
-# it documents: (repo name, license name, link to more info to reupdate list in the future)
-repo_license_exemptions = {"gocd-vault-secret-plugin": {'license':"Apache License 2.0", "more_info":"https://github.com/gocd/gocd-vault-secret-plugin/blob/master/.idea/copyright/Apache_2_0.xml"},
+# it documents: (repo name, license name, link to more info to reupdate list in the future, org (owner) name)
+repo_license_exemptions = {"gocd-vault-secret-plugin": {'license':"Apache License 2.0", "more_info":"https://github.com/edx/gocd-vault-secret-plugin/blob/aaa5de944c599a0df7469b731e7fe1feb1451636/.idea/copyright/Apache_2_0.xml", "owner": "edx"},
                                }
 
 @health_metadata(
@@ -174,9 +174,8 @@ async def check_settings(all_results, github_repo):
     results["last_push"] = github_repo.pushed_at
     repo_license = github_repo.license
     if repo_license is None:
-        if github_repo.name in repo_license_exemptions:
+        if github_repo.name in repo_license_exemptions and github_repo.owner.login == repo_license_exemptions[github_repo.name]["owner"]:
             results["license"] = repo_license_exemptions[github_repo.name]['license']
-            breakpoint()
         else:
             results["license"] = None
     else:

--- a/repo_health/check_github.py
+++ b/repo_health/check_github.py
@@ -114,11 +114,12 @@ async def check_build_duration(all_results, github_repo):
 # Unfortunately, some repositories set their license in a way that does not work with `licensee`.
 # repo_license_exemptions is used to fill in license info for these repositories.
 # it documents: (repo name, license name, more info (link to license), owner (repo org))
-# Since edx/edx-repo-health is a public repository, info about private repositories should not be added here without some deliberation
+# Since edx/edx-repo-health is a public repository,
+# info about private repositories should not be added here without some deliberation
 repo_license_exemptions = {
     "gocd-vault-secret-plugin": {
         "license": "Apache License 2.0",
-        "more_info": "https://github.com/edx/gocd-vault-secret-plugin/blob/v1.2.0-66-exp/.idea/copyright/Apache_2_0.xml",
+        "more_info": "https://github.com/edx/gocd-vault-secret-plugin/blob/v1.2.0-66-exp/.idea/copyright/Apache_2_0.xml",  # pylint: disable=line-too-long
         "owner": "edx",
     },
 }

--- a/repo_health/check_github.py
+++ b/repo_health/check_github.py
@@ -110,9 +110,9 @@ async def check_build_duration(all_results, github_repo):
         'checks': checks_list
     })
 
-# github uses licensee/licensee to figure out the license of a git repository: https://licensee.github.io/licensee/
-# unfortunatly, some repositories don't set their license in a way that does not work in licensee.
-# repo_license_exemtions is used to fill in license info for these repositories
+# GitHub uses https://licensee.github.io/licensee/ to figure out the license of a git repository.
+# Unfortunately, some repositories set their license in a way that does not work with `licensee`.
+# repo_license_exemptions is used to fill in license info for these repositories.
 # it documents: (repo name, license name, link to more info to reupdate list in the future, org (owner) name)
 repo_license_exemptions = {
     "gocd-vault-secret-plugin": {

--- a/tests/test_check_github.py
+++ b/tests/test_check_github.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+import pytest
+import asyncio
+
+from repo_health.check_github import (
+    check_settings,
+    MODULE_DICT_KEY,
+    repo_license_exemptions,
+)
+from unittest.mock import Mock
+
+
+def test_check_settings_license_exemption_present():
+    """Test to make sure having an exemption in repo_license_exemptions results in change of license in all_results dict"""
+    all_results = {MODULE_DICT_KEY: {}}
+    github_repo_mock = Mock()
+    test_repo = "test_repo"
+    test_org = "test_org"
+    test_license = "test_license"
+    repo_license_exemptions[test_repo] = {
+        "license": test_license,
+        "owner": test_org,
+        "more_info": "Bah",
+    }
+
+    github_repo_mock.object.name = test_repo
+    github_repo_mock.object.owner.login = test_org
+    github_repo_mock.object.license = None
+    asyncio.run(check_settings(all_results, github_repo_mock))
+
+    # clean up changes made to repo_license_exemption
+    del repo_license_exemptions[test_repo]
+    assert "license" in all_results["github"]
+    assert all_results["github"]["license"] == test_license
+
+
+def test_check_settings_no_license_exemption_present():
+    """Test to make sure exemptions code does not make any changes when no exemption is present."""
+    all_results = {MODULE_DICT_KEY: {}}
+    github_repo_mock = Mock()
+    test_repo = "test_repo"
+    test_org = "test_org"
+    test_license = "test_license"
+
+    # make sure test_repo is not in repo_license_exemption,
+    # if it is, you might want to change name of test_repo
+    assert test_repo not in repo_license_exemptions
+
+    github_repo_mock.object.license = None
+    asyncio.run(check_settings(all_results, github_repo_mock))
+
+    assert "license" in all_results["github"]
+    assert all_results["github"]["license"] == None

--- a/tests/test_check_github.py
+++ b/tests/test_check_github.py
@@ -11,7 +11,7 @@ from repo_health.check_github import (
 from unittest.mock import Mock
 
 
-def test_check_settings_license_exemption_present():
+async def test_check_settings_license_exemption_present():
     """Test to make sure having an exemption in repo_license_exemptions results in change of license in all_results dict"""
     all_results = {MODULE_DICT_KEY: {}}
     github_repo_mock = Mock()
@@ -27,7 +27,8 @@ def test_check_settings_license_exemption_present():
     github_repo_mock.object.name = test_repo
     github_repo_mock.object.owner.login = test_org
     github_repo_mock.object.license = None
-    asyncio.run(check_settings(all_results, github_repo_mock))
+
+    await check_settings(all_results, github_repo_mock)
 
     # clean up changes made to repo_license_exemption
     del repo_license_exemptions[test_repo]
@@ -35,7 +36,7 @@ def test_check_settings_license_exemption_present():
     assert all_results["github"]["license"] == test_license
 
 
-def test_check_settings_no_license_exemption_present():
+async def test_check_settings_no_license_exemption_present():
     """Test to make sure exemptions code does not make any changes when no exemption is present."""
     all_results = {MODULE_DICT_KEY: {}}
     github_repo_mock = Mock()
@@ -48,7 +49,8 @@ def test_check_settings_no_license_exemption_present():
     assert test_repo not in repo_license_exemptions
 
     github_repo_mock.object.license = None
-    asyncio.run(check_settings(all_results, github_repo_mock))
+
+    await check_settings(all_results, github_repo_mock)
 
     assert "license" in all_results["github"]
     assert all_results["github"]["license"] == None

--- a/tests/test_check_github.py
+++ b/tests/test_check_github.py
@@ -1,18 +1,19 @@
 #!/usr/bin/env python3
+"""Testing functions in repo_health/check_github.py"""
 
-import pytest
-import asyncio
+from unittest.mock import Mock
 
 from repo_health.check_github import (
     check_settings,
     MODULE_DICT_KEY,
     repo_license_exemptions,
 )
-from unittest.mock import Mock
 
 
 async def test_check_settings_license_exemption_present():
-    """Test to make sure having an exemption in repo_license_exemptions results in change of license in all_results dict"""
+    """
+    Test to make sure having an exemption in repo_license_exemptions results in change of license in all_results dict
+    """
     all_results = {MODULE_DICT_KEY: {}}
     github_repo_mock = Mock()
     test_repo = "test_repo"
@@ -37,12 +38,12 @@ async def test_check_settings_license_exemption_present():
 
 
 async def test_check_settings_no_license_exemption_present():
-    """Test to make sure exemptions code does not make any changes when no exemption is present."""
+    """
+    Test to make sure exemptions code does not make any changes when no exemption is present.
+    """
     all_results = {MODULE_DICT_KEY: {}}
     github_repo_mock = Mock()
     test_repo = "test_repo"
-    test_org = "test_org"
-    test_license = "test_license"
 
     # make sure test_repo is not in repo_license_exemption,
     # if it is, you might want to change name of test_repo
@@ -53,4 +54,4 @@ async def test_check_settings_no_license_exemption_present():
     await check_settings(all_results, github_repo_mock)
 
     assert "license" in all_results["github"]
-    assert all_results["github"]["license"] == None
+    assert all_results["github"]["license"] is None


### PR DESCRIPTION
Github is unable to accuratly determine the license of some
repositories. We'd like the data is Repo Health Dashboard to be
accurate, thus adding some hardcoded info for repositories that we know
have licenses.