### PR TITLE
BOM-2749: Add package six in requirements

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -8,6 +8,6 @@ pytest-repo-health         # plugin used to run the checks in this repo
 dockerfile                 # wrapper around docker/docker's parser for dockerfiles.
 
 
-# Needed due to google-auth-oauth package, see details in https://openedx.atlassian.net/browse/BOM-2749
+# Needed due to google-auth-oauthlib package, see details in https://openedx.atlassian.net/browse/BOM-2749
 # Will be removed in https://openedx.atlassian.net/browse/BOM-2750
 six

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -7,3 +7,7 @@ pyyaml                     # Read and write YAML files
 pytest-repo-health         # plugin used to run the checks in this repo
 dockerfile                 # wrapper around docker/docker's parser for dockerfiles.
 
+
+# Needed due to google-auth-oauth package, see details in https://openedx.atlassian.net/browse/BOM-2749
+# Will be removed in https://openedx.atlassian.net/browse/BOM-2750
+six

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -92,6 +92,8 @@ requests-oauthlib==1.3.0
     # via google-auth-oauthlib
 rsa==4.7.2
     # via google-auth
+six==1.16.0
+    # via -r requirements/base.in
 smmap==4.0.0
     # via gitdb
 toml==0.10.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -148,7 +148,9 @@ rsa==4.7.2
     #   -r requirements/base.txt
     #   google-auth
 six==1.16.0
-    # via responses
+    # via
+    #   -r requirements/base.txt
+    #   responses
 smmap==4.0.0
     # via
     #   -r requirements/base.txt


### PR DESCRIPTION
**Issue:** [BOM-2749](https://openedx.atlassian.net/browse/BOM-2749)

### Description
- Package `six` was removed with the new version of `googl-auth` in https://github.com/edx/edx-repo-health/pull/205 but we need it for `google-auth-oauthlib`. Currently the fix in the `google-auth-oauthlib` package is not out which is causing the Repo Health Jobs to fail, so adding `six` in requirements to fix that.

### Testing
- The failing Repo Health Report job ran successfully with this branch to verify the change: 
  https://tools-edx-jenkins.edx.org/view/All%20Jobs/job/RepoHealth/job/org-repo-health-report/567/.

### TODO

- This'll be removed later on in https://openedx.atlassian.net/browse/BOM-2750 when `googl-auth-oautlib>0.4.5` is released.