### PR TITLE
BOM-2750: Removed six and added django in quality requirements

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -6,8 +6,3 @@ gspread                    # Access information from Google Sheets (the ownershi
 pyyaml                     # Read and write YAML files
 pytest-repo-health         # plugin used to run the checks in this repo
 dockerfile                 # wrapper around docker/docker's parser for dockerfiles.
-
-
-# Needed due to google-auth-oauthlib package, see details in https://openedx.atlassian.net/browse/BOM-2749
-# Will be removed in https://openedx.atlassian.net/browse/BOM-2750
-six

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -32,11 +32,11 @@ git+https://github.com/ShineyDev/github.py.git@8e3514010eb35a91e012f2935f48138b3
     # via -r requirements/github.in
 gitpython==3.1.18
     # via pytest-repo-health
-google-auth==2.0.1
+google-auth==2.0.2
     # via
     #   google-auth-oauthlib
     #   gspread
-google-auth-oauthlib==0.4.5
+google-auth-oauthlib==0.4.6
     # via gspread
 gspread==4.0.1
     # via -r requirements/base.in
@@ -62,7 +62,7 @@ oauthlib==3.1.1
     # via requests-oauthlib
 packaging==21.0
     # via pytest
-pluggy==0.13.1
+pluggy==1.0.0
     # via pytest
 py==1.10.0
     # via pytest
@@ -74,7 +74,7 @@ pyasn1-modules==0.2.8
     # via google-auth
 pyparsing==2.4.7
     # via packaging
-pytest==6.2.4
+pytest==6.2.5
     # via
     #   pytest-aiohttp
     #   pytest-repo-health
@@ -92,13 +92,11 @@ requests-oauthlib==1.3.0
     # via google-auth-oauthlib
 rsa==4.7.2
     # via google-auth
-six==1.16.0
-    # via -r requirements/base.in
 smmap==4.0.0
     # via gitdb
 toml==0.10.2
     # via pytest
-typing-extensions==3.10.0.0
+typing-extensions==3.10.0.2
     # via
     #   aiohttp
     #   gitpython

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -33,9 +33,9 @@ importlib-resources==5.2.2
     # via virtualenv
 packaging==21.0
     # via tox
-platformdirs==2.2.0
+platformdirs==2.3.0
     # via virtualenv
-pluggy==0.13.1
+pluggy==1.0.0
     # via tox
 py==1.10.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,7 +9,7 @@ aiohttp==3.7.4.post0
     #   -r requirements/quality.txt
     #   github.py
     #   pytest-aiohttp
-astroid==2.7.2
+astroid==2.7.3
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -82,10 +82,9 @@ django==2.2.24
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/quality.txt
-    #   edx-lint
 dockerfile==3.1.0
     # via -r requirements/quality.txt
-edx-lint==5.0.0
+edx-lint==5.1.0
     # via -r requirements/quality.txt
 filelock==3.0.12
     # via
@@ -102,12 +101,12 @@ gitpython==3.1.18
     # via
     #   -r requirements/quality.txt
     #   pytest-repo-health
-google-auth==2.0.1
+google-auth==2.0.2
     # via
     #   -r requirements/quality.txt
     #   google-auth-oauthlib
     #   gspread
-google-auth-oauthlib==0.4.5
+google-auth-oauthlib==0.4.6
     # via
     #   -r requirements/quality.txt
     #   gspread
@@ -197,13 +196,13 @@ pep517==0.11.0
     #   pip-tools
 pip-tools==6.2.0
     # via -r requirements/pip-tools.txt
-platformdirs==2.2.0
+platformdirs==2.3.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   pylint
     #   virtualenv
-pluggy==0.13.1
+pluggy==1.0.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
@@ -256,7 +255,7 @@ pyparsing==2.4.7
     #   -r requirements/ci.txt
     #   -r requirements/quality.txt
     #   packaging
-pytest==6.2.4
+pytest==6.2.5
     # via
     #   -r requirements/quality.txt
     #   pytest-aiohttp
@@ -350,7 +349,7 @@ typed-ast==1.4.3
     # via
     #   -r requirements/quality.txt
     #   astroid
-typing-extensions==3.10.0.0
+typing-extensions==3.10.0.2
     # via
     #   -r requirements/quality.txt
     #   aiohttp

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -22,7 +22,7 @@ attrs==21.2.0
     #   pytest
 babel==2.9.1
     # via sphinx
-bleach==4.0.0
+bleach==4.1.0
     # via readme-renderer
 cachetools==4.2.2
     # via
@@ -67,12 +67,12 @@ gitpython==3.1.18
     # via
     #   -r requirements/test.txt
     #   pytest-repo-health
-google-auth==2.0.1
+google-auth==2.0.2
     # via
     #   -r requirements/test.txt
     #   google-auth-oauthlib
     #   gspread
-google-auth-oauthlib==0.4.5
+google-auth-oauthlib==0.4.6
     # via
     #   -r requirements/test.txt
     #   gspread
@@ -122,7 +122,7 @@ packaging==21.0
     #   sphinx
 pbr==5.6.0
     # via stevedore
-pluggy==0.13.1
+pluggy==1.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -148,7 +148,7 @@ pyparsing==2.4.7
     # via
     #   -r requirements/test.txt
     #   packaging
-pytest==6.2.4
+pytest==6.2.5
     # via
     #   -r requirements/test.txt
     #   pytest-aiohttp
@@ -224,7 +224,7 @@ toml==0.10.2
     #   -r requirements/test.txt
     #   pytest
     #   pytest-cov
-typing-extensions==3.10.0.0
+typing-extensions==3.10.0.2
     # via
     #   -r requirements/test.txt
     #   aiohttp

--- a/requirements/quality.in
+++ b/requirements/quality.in
@@ -7,3 +7,4 @@ edx-lint                  # edX pylint rules and plugins
 isort                     # to standardize order of imports
 pycodestyle               # PEP 8 compliance validation
 pydocstyle                # PEP 257 compliance validation
+django                    # Needed for pylint-django checks in quality

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -9,7 +9,7 @@ aiohttp==3.7.4.post0
     #   -r requirements/test.txt
     #   github.py
     #   pytest-aiohttp
-astroid==2.7.2
+astroid==2.7.3
     # via
     #   pylint
     #   pylint-celery
@@ -55,10 +55,10 @@ coverage==5.5
 django==2.2.24
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
-    #   edx-lint
+    #   -r requirements/quality.in
 dockerfile==3.1.0
     # via -r requirements/test.txt
-edx-lint==5.0.0
+edx-lint==5.1.0
     # via -r requirements/quality.in
 gitdb==4.0.7
     # via
@@ -70,12 +70,12 @@ gitpython==3.1.18
     # via
     #   -r requirements/test.txt
     #   pytest-repo-health
-google-auth==2.0.1
+google-auth==2.0.2
     # via
     #   -r requirements/test.txt
     #   google-auth-oauthlib
     #   gspread
-google-auth-oauthlib==0.4.5
+google-auth-oauthlib==0.4.6
     # via
     #   -r requirements/test.txt
     #   gspread
@@ -130,9 +130,9 @@ packaging==21.0
     #   pytest
 pbr==5.6.0
     # via stevedore
-platformdirs==2.2.0
+platformdirs==2.3.0
     # via pylint
-pluggy==0.13.1
+pluggy==1.0.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -171,7 +171,7 @@ pyparsing==2.4.7
     # via
     #   -r requirements/test.txt
     #   packaging
-pytest==6.2.4
+pytest==6.2.5
     # via
     #   -r requirements/test.txt
     #   pytest-aiohttp
@@ -234,7 +234,7 @@ toml==0.10.2
     #   pytest-cov
 typed-ast==1.4.3
     # via astroid
-typing-extensions==3.10.0.0
+typing-extensions==3.10.0.2
     # via
     #   -r requirements/test.txt
     #   aiohttp

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -49,12 +49,12 @@ gitpython==3.1.18
     # via
     #   -r requirements/base.txt
     #   pytest-repo-health
-google-auth==2.0.1
+google-auth==2.0.2
     # via
     #   -r requirements/base.txt
     #   google-auth-oauthlib
     #   gspread
-google-auth-oauthlib==0.4.5
+google-auth-oauthlib==0.4.6
     # via
     #   -r requirements/base.txt
     #   gspread
@@ -93,7 +93,7 @@ packaging==21.0
     # via
     #   -r requirements/base.txt
     #   pytest
-pluggy==0.13.1
+pluggy==1.0.0
     # via
     #   -r requirements/base.txt
     #   pytest
@@ -114,7 +114,7 @@ pyparsing==2.4.7
     # via
     #   -r requirements/base.txt
     #   packaging
-pytest==6.2.4
+pytest==6.2.5
     # via
     #   -r requirements/base.txt
     #   pytest-aiohttp
@@ -148,9 +148,7 @@ rsa==4.7.2
     #   -r requirements/base.txt
     #   google-auth
 six==1.16.0
-    # via
-    #   -r requirements/base.txt
-    #   responses
+    # via responses
 smmap==4.0.0
     # via
     #   -r requirements/base.txt
@@ -160,7 +158,7 @@ toml==0.10.2
     #   -r requirements/base.txt
     #   pytest
     #   pytest-cov
-typing-extensions==3.10.0.0
+typing-extensions==3.10.0.2
     # via
     #   -r requirements/base.txt
     #   aiohttp


### PR DESCRIPTION
**Issue:** [BOM-2750](https://openedx.atlassian.net/browse/BOM-2750)

### Description
- Package `six` was added in the requirements due to `google-auth-oauthlib` package. Now that `google-auth-oauthlib==0.4.6` is out with the fix, removed the `six` requirement.
- Added `django` in quality requirements which is needed for `pylint-django` quality checks. Previously `edx-lint` had it in the base requirements but now the new version of `edx-lint==5.1.0` has removed it from the base dependencies so we need to install in the quality requirements.