### PR TITLE
Fix issues with version

### DIFF
--- a/repo_health/__init__.py
+++ b/repo_health/__init__.py
@@ -8,7 +8,7 @@ import glob
 import pytest
 import dockerfile
 
-__version__ = "0.1.8"
+__version__ = "0.2.0"
 
 
 GITHUB_URL_PATTERN = r"github.com[/:](?P<org_name>[^/]+)/(?P<repo_name>[^/]+).*#egg=(?P<package>[^\/]+).*"

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,11 @@ import sys
 from setuptools import setup
 
 
-def get_version(*file_paths):
+def get_version(file_path):
     """
     Extract the version string from the file at the given relative path fragments.
     """
-    filename = os.path.join(os.path.dirname(__file__), *file_paths)
+    filename = os.path.join(os.path.dirname(__file__), file_path)
     version_file = open(filename, encoding="utf8").read()  # pylint: disable=consider-using-with
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]", version_file, re.M)
     if version_match:
@@ -88,7 +88,7 @@ def is_requirement(line):
     return line and line.strip() and not line.startswith(('-r', '#', '-e', 'git+', '-c'))
 
 
-VERSION = "0.2.0"
+VERSION = get_version("repo_health/__init__.py")
 
 if sys.argv[-1] == "tag":
     print("Tagging the version on github:")


### PR DESCRIPTION
This PR makes sure that this repo follows the standard that we have set across repos in the edX organization to fetch version number from `__init__.py`. 
Also I noticed that version number was placed at two different places so picked the latest one and retained that.
For more Insights into this [ARCH-BOM_DISCUSSION](https://edx-internal.slack.com/archives/CG7FM3BLY/p1636049435194900)